### PR TITLE
Make Poisson sampling opt-in in the Keras DP path

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Choquette-Choo, Christopher A and De, Soham and Doroshenko, Vadym and Dvijotham,
 Dj and Galen, Andrew and Ganesh, Arun and Ghalebikesabi, Sahra and Hayes, Jamie
 and Kairouz, Peter and McKenna, Ryan and McMahan, Brendan and Pappu, Aneesh and
 Ponomareva, Natalia and Pravilov, Mikhail and Rush, Keith and Smith, Samuel L
-and Stanforth, Robert},
+and Stanforth, Robert and Mishra, Chaitanya},
   title = {{JAX}-{P}rivacy: Algorithms for Privacy-Preserving Machine Learning in JAX},
   url = {http://github.com/google-deepmind/jax_privacy},
   version = {0.4.0},

--- a/docs/keras_api.rst
+++ b/docs/keras_api.rst
@@ -37,6 +37,10 @@ example below shows that.
 This section demonstrates how to integrate the Keras API into a typical
 Keras training workflow.
 
+The example below enables ``poisson_sampling_in_fit`` and passes training data
+to ``fit()`` as per-example arrays. In that setup, the DP Keras wrapper draws
+Poisson-sampled batches internally from those arrays.
+
 .. literalinclude:: ../examples/keras_api_example.py
    :language: python
    :linenos:

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -57,5 +57,6 @@ Then on top of the core library the following backend-specific public high-level
 
 These APIs abstract some complexity and reduce the amount of code necessary to
 implement DP training at the cost of less flexibility. Currently, the only
-supported mechanism available when using the Keras API is DP-SGD with shuffling
-and batching (with accounting done assuming Poisson sampling).
+supported mechanism available when using the Keras API is DP-SGD with
+internally Poisson-sampled batches built from random-access per-example arrays
+(with accounting done using the same Poisson-sampling assumption).

--- a/examples/keras_api_example.py
+++ b/examples/keras_api_example.py
@@ -74,13 +74,14 @@ def main(_):
   # Marker to insert the main part of the example into ReadTheDocs.
   # [START example]
   (x_train, y_train), (x_test, y_test) = load_data()
+  batch_size = 128
+  train_size = (len(x_train) // batch_size) * batch_size
+  x_train, y_train = x_train[:train_size], y_train[:train_size]
   model = get_model()
 
   epsilon = 1.1
   delta = 1e-5
-  batch_size = 128
   epochs = 5
-  train_size = len(x_train)
   dp = True
   clipping_norm = 1.0
 
@@ -110,15 +111,27 @@ def main(_):
       optimizer="adam",
       metrics=["accuracy"],
   )
-  model.fit(
-      x_train,
-      y_train,
+  fit_kwargs = dict(
+      x=x_train,
+      y=y_train,
       epochs=epochs,
       validation_data=(x_test, y_test),
   )
+  if not dp:
+    fit_kwargs["batch_size"] = batch_size
+  history = model.fit(**fit_kwargs)
   # [END example]
   print("DP: expected train accuracy: ~96%, val accuracy: ~92%")
   print("Non-DP: expected train accuracy: ~98%, val accuracy: ~98%")
+  final_accuracy = history.history["accuracy"][-1]
+  if dp:
+    assert (
+        final_accuracy > 0.85
+    ), f"DP Accuracy {final_accuracy:.4f} is too low!"
+  else:
+    assert (
+        final_accuracy > 0.95
+    ), f"Non-DP Accuracy {final_accuracy:.4f} is too low!"
 
 
 if __name__ == "__main__":

--- a/examples/keras_api_example.py
+++ b/examples/keras_api_example.py
@@ -74,13 +74,11 @@ def main(_):
   # Marker to insert the main part of the example into ReadTheDocs.
   # [START example]
   (x_train, y_train), (x_test, y_test) = load_data()
-  batch_size = 128
-  train_size = (len(x_train) // batch_size) * batch_size
-  x_train, y_train = x_train[:train_size], y_train[:train_size]
   model = get_model()
 
   epsilon = 1.1
   delta = 1e-5
+  batch_size = 128
   epochs = 5
   train_size = len(x_train)
   dp = True
@@ -94,6 +92,7 @@ def main(_):
         batch_size=batch_size,
         train_steps=epochs * (train_size // batch_size),
         train_size=train_size,
+        poisson_sampling_in_fit=True,
         seed=0,
         gradient_accumulation_steps=1,
     )
@@ -102,6 +101,8 @@ def main(_):
         f"DP training:{epsilon=} {delta=} {clipping_norm=} {batch_size=} "
         f"{epochs=} {train_size=}"
     )
+    # This example opts into internal Poisson sampling from the per-example
+    # arrays passed to fit().
   else:
     print("Non-DP training")
   model.compile(
@@ -109,25 +110,15 @@ def main(_):
       optimizer="adam",
       metrics=["accuracy"],
   )
-  history = model.fit(
+  model.fit(
       x_train,
       y_train,
-      batch_size=batch_size,
       epochs=epochs,
       validation_data=(x_test, y_test),
   )
   # [END example]
   print("DP: expected train accuracy: ~96%, val accuracy: ~92%")
   print("Non-DP: expected train accuracy: ~98%, val accuracy: ~98%")
-  final_accuracy = history.history["accuracy"][-1]
-  if dp:
-    assert (
-        final_accuracy > 0.85
-    ), f"DP Accuracy {final_accuracy:.4f} is too low!"
-  else:
-    assert (
-        final_accuracy > 0.95
-    ), f"Non-DP Accuracy {final_accuracy:.4f} is too low!"
 
 
 if __name__ == "__main__":

--- a/jax_privacy/batch_selection.py
+++ b/jax_privacy/batch_selection.py
@@ -25,31 +25,6 @@ the data on disk before loading into your training pipeline.
 The implementations in this file generally materialize a vector of indices of
 size `num_examples` and hence it requires that this object fits in memory,
 i.e., roughly that num_examples < 1e9.
-
-The examples below demonstrate how to use the BatchSelectionStrategy API.
-via the CyclicPoissonSampling implementation (all with expected batch size 3):
-
-Example Usage (fixed order + multi-epoch) [1]:
-  >>> rng = np.random.default_rng(0)
-  >>> b = CyclicPoissonSampling(sampling_prob=1, iterations=8, cycle_length=4)
-  >>> print(*b.batch_iterator(12, rng=rng), sep=' ')
-  [9 2 7] [ 4  5 11] [0 3 6] [10  8  1] [9 2 7] [ 4  5 11] [0 3 6] [10  8  1]
-
-Example Usage (standard Poisson sampling) [2]:
-  >>> b = CyclicPoissonSampling(sampling_prob=0.25, iterations=8)
-  >>> print(*b.batch_iterator(12, rng=rng), sep=' ')
-  [5 6 7] [5 8 3 7 2] [ 1  5 11] [0 3] [ 5  1  3  4 10] [2] [4 5 1 3] [6]
-
-Example Usage (BandMF-style sampling) [3]:
-  >>> p = 0.5
-  >>> b = CyclicPoissonSampling(sampling_prob=p, iterations=6, cycle_length=2)
-  >>> print(*b.batch_iterator(12, rng=rng), sep=' ')
-  [2 4] [1 8 9] [2 7 5 4] [11  1  3] [10  2  5  0  4] [ 1 11  6]
-
-References:
-[1] https://arxiv.org/abs/2211.06530
-[2] https://arxiv.org/abs/1607.00133
-[3] https://arxiv.org/abs/2306.08153
 """
 
 import abc
@@ -159,6 +134,8 @@ def pad_to_multiple_of(indices: np.ndarray, multiple: int) -> np.ndarray:
   """
   if indices.ndim > 1:
     raise ValueError('pad_to_multiple_of currently expects 1D indices.')
+  if multiple <= 0:
+    raise ValueError(f'Padding multiple must be positive, got {multiple}.')
   curr_size = indices.shape[0]
   pad_size = (multiple - curr_size) % multiple
   new_indices = np.full(curr_size + pad_size, -1, dtype=indices.dtype)
@@ -191,7 +168,26 @@ class BatchSelectionStrategy(abc.ABC):
 class CyclicPoissonSampling(BatchSelectionStrategy):
   """Implements Poisson sampling, possibly with cyclic sampling and truncation.
 
-  This generalizes several common sampling strategies [1,2,3,4],
+  This generalizes several common sampling strategies [1,2,3,4], exemplified
+  below (all with expected batch size 3):
+
+  Example Usage (fixed order + multi-epoch) [1]:
+    >>> rng = np.random.default_rng(0)
+    >>> b = CyclicPoissonSampling(sampling_prob=1, iterations=8, cycle_length=4)
+    >>> print(*b.batch_iterator(12, rng=rng), sep=' ')
+    [9 2 7] [ 4  5 11] [0 3 6] [10  8  1] [9 2 7] [ 4  5 11] [0 3 6] [10  8  1]
+
+  Example Usage (standard Poisson sampling) [2]:
+    >>> b = CyclicPoissonSampling(sampling_prob=0.25, iterations=8)
+    >>> print(*b.batch_iterator(12, rng=rng), sep=' ')
+    [5 6 7] [5 8 3 7 2] [ 1  5 11] [0 3] [ 5  1  3  4 10] [2] [4 5 1 3] [6]
+
+  Example Usage (BandMF-style sampling) [3]:
+    >>> p = 0.5
+    >>> b = CyclicPoissonSampling(sampling_prob=p, iterations=6, cycle_length=2)
+    >>> print(*b.batch_iterator(12, rng=rng), sep=' ')
+    [2 4] [1 8 9] [2 7 5 4] [11  1  3] [10  2  5  0  4] [ 1 11  6]
+
 
   References:
   [1] https://arxiv.org/abs/2211.06530

--- a/jax_privacy/batch_selection.py
+++ b/jax_privacy/batch_selection.py
@@ -25,6 +25,31 @@ the data on disk before loading into your training pipeline.
 The implementations in this file generally materialize a vector of indices of
 size `num_examples` and hence it requires that this object fits in memory,
 i.e., roughly that num_examples < 1e9.
+
+The examples below demonstrate how to use the BatchSelectionStrategy API.
+via the CyclicPoissonSampling implementation (all with expected batch size 3):
+
+Example Usage (fixed order + multi-epoch) [1]:
+  >>> rng = np.random.default_rng(0)
+  >>> b = CyclicPoissonSampling(sampling_prob=1, iterations=8, cycle_length=4)
+  >>> print(*b.batch_iterator(12, rng=rng), sep=' ')
+  [9 2 7] [ 4  5 11] [0 3 6] [10  8  1] [9 2 7] [ 4  5 11] [0 3 6] [10  8  1]
+
+Example Usage (standard Poisson sampling) [2]:
+  >>> b = CyclicPoissonSampling(sampling_prob=0.25, iterations=8)
+  >>> print(*b.batch_iterator(12, rng=rng), sep=' ')
+  [5 6 7] [5 8 3 7 2] [ 1  5 11] [0 3] [ 5  1  3  4 10] [2] [4 5 1 3] [6]
+
+Example Usage (BandMF-style sampling) [3]:
+  >>> p = 0.5
+  >>> b = CyclicPoissonSampling(sampling_prob=p, iterations=6, cycle_length=2)
+  >>> print(*b.batch_iterator(12, rng=rng), sep=' ')
+  [2 4] [1 8 9] [2 7 5 4] [11  1  3] [10  2  5  0  4] [ 1 11  6]
+
+References:
+[1] https://arxiv.org/abs/2211.06530
+[2] https://arxiv.org/abs/1607.00133
+[3] https://arxiv.org/abs/2306.08153
 """
 
 import abc
@@ -168,26 +193,7 @@ class BatchSelectionStrategy(abc.ABC):
 class CyclicPoissonSampling(BatchSelectionStrategy):
   """Implements Poisson sampling, possibly with cyclic sampling and truncation.
 
-  This generalizes several common sampling strategies [1,2,3,4], exemplified
-  below (all with expected batch size 3):
-
-  Example Usage (fixed order + multi-epoch) [1]:
-    >>> rng = np.random.default_rng(0)
-    >>> b = CyclicPoissonSampling(sampling_prob=1, iterations=8, cycle_length=4)
-    >>> print(*b.batch_iterator(12, rng=rng), sep=' ')
-    [9 2 7] [ 4  5 11] [0 3 6] [10  8  1] [9 2 7] [ 4  5 11] [0 3 6] [10  8  1]
-
-  Example Usage (standard Poisson sampling) [2]:
-    >>> b = CyclicPoissonSampling(sampling_prob=0.25, iterations=8)
-    >>> print(*b.batch_iterator(12, rng=rng), sep=' ')
-    [5 6 7] [5 8 3 7 2] [ 1  5 11] [0 3] [ 5  1  3  4 10] [2] [4 5 1 3] [6]
-
-  Example Usage (BandMF-style sampling) [3]:
-    >>> p = 0.5
-    >>> b = CyclicPoissonSampling(sampling_prob=p, iterations=6, cycle_length=2)
-    >>> print(*b.batch_iterator(12, rng=rng), sep=' ')
-    [2 4] [1 8 9] [2 7 5 4] [11  1  3] [10  2  5  0  4] [ 1 11  6]
-
+  This generalizes several common sampling strategies [1,2,3,4].
 
   References:
   [1] https://arxiv.org/abs/2211.06530

--- a/jax_privacy/keras_api.py
+++ b/jax_privacy/keras_api.py
@@ -45,6 +45,7 @@ from collections.abc import Callable
 import dataclasses
 import functools
 import inspect
+import math
 import types
 from typing import Any
 
@@ -52,6 +53,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax_privacy
+from jax_privacy import batch_selection
 from jax_privacy.accounting import accountants
 from jax_privacy.accounting import analysis
 from jax_privacy.accounting import calibrate
@@ -78,7 +80,10 @@ class DPKerasConfig:
         privacy guarantees you have to achieve. You should not increase the
         delta only because of poor model performance.
       clipping_norm: The clipping norm for the per-example gradients.
-      batch_size: The batch size for the training.
+      batch_size: The batch size used by the DP optimizer. When
+        `poisson_sampling_in_fit=True`, this is the expected batch size of the
+        internal Poisson sampler. Otherwise it must match the batch size
+        supplied to `fit()`.
       gradient_accumulation_steps: The number of gradient accumulation steps.
         This is the number of batches to accumulate before adding noise and
         performing an optimizer step. 1 means that there is no gradient
@@ -99,6 +104,10 @@ class DPKerasConfig:
       train_size: The number of training examples in the dataset. If you repeat
         the examples in your dataset iterator, it should be the number of
         training examples in the original dataset before repeating.
+      poisson_sampling_in_fit: Whether `fit()` should internally resample
+        random-access array inputs using Poisson sampling. Leave this as False
+        for backwards-compatible behavior or when the user supplies a dataset
+        iterator that already handles sampling.
       noise_multiplier: The noise multiplier for the gradients. If None
         (recommended), the noise multiplier will be automatically calculated
         based on epsilon, delta, effective_batch_size, train_steps and
@@ -133,6 +142,7 @@ class DPKerasConfig:
   gradient_accumulation_steps: int
   train_steps: int
   train_size: int
+  poisson_sampling_in_fit: bool = False
   noise_multiplier: float | None = None
   rescale_to_unit_norm: bool = True
   microbatch_size: int | None = None
@@ -194,15 +204,30 @@ class DPKerasConfig:
       raise ValueError(f'Clipping norm {self.clipping_norm} must be positive.')
     if self.batch_size <= 0:
       raise ValueError(f'Batch size {self.batch_size} must be positive.')
-    if self.train_steps <= 0:
-      raise ValueError(f'Train steps {self.train_steps} must be positive.')
     if self.train_size <= 0:
       raise ValueError(f'Train size {self.train_size} must be positive.')
+    if self.batch_size > self.train_size:
+      raise ValueError(
+          f'Batch size {self.batch_size} must be less than or equal to train'
+          f' size {self.train_size}.'
+      )
+    if self.train_steps <= 0:
+      raise ValueError(f'Train steps {self.train_steps} must be positive.')
     if self.gradient_accumulation_steps <= 0:
       raise ValueError(
           f'Gradient accumulation steps {self.gradient_accumulation_steps} must'
           ' be positive.'
       )
+    if self.microbatch_size is not None:
+      if self.microbatch_size <= 0:
+        raise ValueError(
+            f'Microbatch size {self.microbatch_size} must be positive.'
+        )
+      if self.microbatch_size > self.batch_size:
+        raise ValueError(
+            f'Microbatch size {self.microbatch_size} must be less than or'
+            f' equal to batch size {self.batch_size}.'
+        )
     if self.noise_multiplier is not None:
       if self.noise_multiplier <= 0:
         raise ValueError(
@@ -240,16 +265,18 @@ class DPKerasConfig:
 def make_private(model: keras.Model, params: DPKerasConfig) -> keras.Model:
   """Adds DP-SGD training to a Keras model without modifying its API.
 
-  This function modifies `model` in-place by adding attributes and replaces
-  methods (e.g. it replaces train_step) and returns the modified model. The API
-  of the model is not modified, i.e. you can use it as a usual Keras model.
+  This function mutates ``model`` in place, installs the DP-SGD hooks, and
+  returns the same model instance. When
+  ``params.poisson_sampling_in_fit`` is enabled, the wrapped ``fit()`` path
+  expects random-access per-example arrays or pytrees of arrays so it can
+  perform Poisson sampling internally.
 
   Args:
     model: The Keras model to add DP-SGD training to.
     params: The parameters for DP-SGD training.
 
   Returns:
-    The Keras model with overloaded methods for DP-SGD training.
+    The input model with overloaded methods for DP-SGD training.
   """
   _validate_model(model)
 
@@ -353,6 +380,222 @@ def _add_dp_sgd_attributes(model: keras.Model, params: DPKerasConfig) -> None:
 
 
 _FitFnReturnType = keras.callbacks.History
+_DEFAULT_POISSON_PADDING_MULTIPLE = 32
+
+
+class _PoissonSampledTrainingDataset(keras.utils.PyDataset):
+  """Keras dataset serving Poisson-sampled batches from random-access data."""
+
+  def __init__(
+      self,
+      x: chex.ArrayTree,
+      y: chex.ArrayTree | None,
+      sample_weight: chex.ArrayTree | None,
+      *,
+      dp_params: DPKerasConfig,
+      steps_per_epoch: int,
+  ):
+    super().__init__()
+    self._x = x
+    self._y = y
+    self._sample_weight = sample_weight
+    self._train_size = _tree_batch_size(x)
+    self._steps_per_epoch = steps_per_epoch
+    self._sampling_prob = dp_params.batch_size / float(self._train_size)
+    self._padding_multiple = _get_poisson_padding_multiple(dp_params)
+    seed = _get_random_int64() if dp_params.seed is None else dp_params.seed
+    self._rng = np.random.default_rng(seed)
+    self._epoch_batches = []
+    self.on_epoch_end()
+
+  def __len__(self) -> int:
+    return self._steps_per_epoch
+
+  def __getitem__(
+      self, index: int
+  ) -> tuple[chex.ArrayTree, chex.ArrayTree | None, chex.ArrayTree]:
+    padded_indices = self._epoch_batches[index]
+    batched_x = _take_batch_from_tree(self._x, padded_indices)
+    batched_y = _take_batch_from_tree(self._y, padded_indices)
+    batched_sample_weight = _build_batch_sample_weight(
+        self._sample_weight, padded_indices
+    )
+    return batched_x, batched_y, batched_sample_weight
+
+  def on_epoch_end(self) -> None:
+    """Precomputes one epoch of padded Poisson-sampled index batches."""
+    strategy = batch_selection.CyclicPoissonSampling(
+        sampling_prob=self._sampling_prob,
+        iterations=self._steps_per_epoch,
+    )
+    self._epoch_batches = [
+        _pad_batch_indices(np.asarray(indices), self._padding_multiple)
+        for indices in strategy.batch_iterator(self._train_size, rng=self._rng)
+    ]
+
+
+def _is_var_keyword_parameter(parameter: inspect.Parameter) -> bool:
+  """Returns whether a signature entry corresponds to ``**kwargs``."""
+  return parameter.kind is inspect.Parameter.VAR_KEYWORD
+
+
+def _normalize_bound_fit_arguments(
+    fit_signature: inspect.Signature,
+    *args,
+    **kwargs,
+) -> dict[str, Any]:
+  """Normalizes fit arguments into a kwargs-only call."""
+  bound_arguments = fit_signature.bind_partial(*args, **kwargs)
+  normalized_kwargs = {}
+  for name, value in bound_arguments.arguments.items():
+    parameter = fit_signature.parameters[name]
+    if _is_var_keyword_parameter(parameter):
+      # Flatten any bound **kwargs entry exposed by the wrapped Keras model.
+      normalized_kwargs.update(value)
+    else:
+      normalized_kwargs[name] = value
+  return normalized_kwargs
+
+
+def _prepare_fit_kwargs_for_poisson_dataset(
+    fit_kwargs: dict[str, Any],
+    *,
+    poisson_dataset: _PoissonSampledTrainingDataset,
+) -> dict[str, Any]:
+  """Swaps array inputs for a PyDataset and removes consumed fit arguments."""
+  fit_kwargs = dict(fit_kwargs)
+  fit_kwargs['x'] = poisson_dataset
+  # Once x becomes a PyDataset, Keras expects targets and sample weights to be
+  # yielded by the dataset rather than passed as separate fit arguments.
+  for key in (
+      'y',
+      'sample_weight',
+      'batch_size',
+      'shuffle',
+      'validation_split',
+  ):
+    fit_kwargs.pop(key, None)
+  if fit_kwargs.get('steps_per_epoch') is None:
+    fit_kwargs.pop('steps_per_epoch', None)
+  return fit_kwargs
+
+
+def _get_poisson_padding_multiple(dp_params: DPKerasConfig) -> int:
+  if dp_params.microbatch_size is not None:
+    return dp_params.microbatch_size
+  return max(1, min(dp_params.batch_size, _DEFAULT_POISSON_PADDING_MULTIPLE))
+
+
+def _pad_batch_indices(indices: np.ndarray, multiple: int) -> np.ndarray:
+  """Pads indices with -1 so empty Poisson draws are still representable."""
+  if indices.size == 0:
+    return np.full(multiple, -1, dtype=np.int32)
+  return batch_selection.pad_to_multiple_of(indices, multiple)
+
+
+def _tree_batch_size(tree: chex.ArrayTree) -> int:
+  """Returns and validates the batch size of a pytree of arrays."""
+  leaves = jax.tree.leaves(tree)
+  # Expected input: a non-empty pytree of random-access arrays whose leaves all
+  # share the same leading batch dimension.
+  if not leaves:
+    raise ValueError('Expected at least one array leaf in the training data.')
+  batch_size = None
+  for leaf in leaves:
+    if not hasattr(leaf, 'shape'):
+      raise ValueError(
+          'DP Keras training requires random-access array-like inputs.'
+      )
+    if not leaf.shape:
+      raise ValueError(
+          'DP Keras training requires each input leaf to have a batch'
+          ' dimension.'
+      )
+    try:
+      np.asarray(leaf[:1])
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+      raise ValueError(
+          'DP Keras training requires random-access array-like inputs.'
+      ) from exc
+    leaf_batch_size = leaf.shape[0]
+    if batch_size is None:
+      batch_size = leaf_batch_size
+    elif leaf_batch_size != batch_size:
+      raise ValueError(
+          'All training data leaves must agree on their leading batch'
+          ' dimension.'
+      )
+  return int(batch_size)
+
+
+def _take_batch_from_leaf(leaf: chex.Array, indices: np.ndarray) -> np.ndarray:
+  """Slices one batched leaf and zero-fills padded ``-1`` index positions."""
+  leaf = np.asarray(leaf)
+  valid_positions = indices >= 0
+  batch = np.zeros((indices.shape[0],) + leaf.shape[1:], dtype=leaf.dtype)
+  if np.any(valid_positions):
+    batch[valid_positions] = leaf[indices[valid_positions]]
+  return batch
+
+
+def _take_batch_from_tree(
+    tree: chex.ArrayTree | None, indices: np.ndarray
+) -> chex.ArrayTree | None:
+  if tree is None:
+    return None
+  return jax.tree.map(lambda leaf: _take_batch_from_leaf(leaf, indices), tree)
+
+
+def _build_batch_sample_weight(
+    sample_weight: chex.ArrayTree | None,
+    indices: np.ndarray,
+) -> chex.ArrayTree:
+  """Builds sample weights that hide synthetic padding examples from Keras."""
+  if sample_weight is None:
+    return (indices >= 0).astype(np.float32)
+  return _take_batch_from_tree(sample_weight, indices)
+
+
+def _padding_mask_from_sample_weight(
+    sample_weight: jax.Array,
+) -> jax.Array:
+  """Returns which batch entries are synthetic padding examples."""
+  sample_weight = jnp.asarray(sample_weight)
+  if sample_weight.ndim == 1:
+    return sample_weight == 0
+  if sample_weight.ndim == 2:
+    return ~jnp.any(sample_weight, axis=1)
+  raise ValueError('Expected sample_weight to be a 1D or 2D array.')
+
+
+def _maybe_symbolically_build_private_model(
+    model: keras.Model, dataset: _PoissonSampledTrainingDataset
+) -> None:
+  """Runs Keras' symbolic build before fit() sees the Poisson dataset."""
+  if not hasattr(model, '_symbolic_build'):
+    return
+  # _symbolic_build is a private Keras helper, not a JAX-specific concept.
+  # It lets Keras infer shapes and create state from a standard
+  # (x, y, sample_weight) batch before the wrapped fit() path starts yielding
+  # Poisson-sampled batches from the PyDataset. Without this eager build step,
+  # lazily-built models can reach the wrapped fit() path before Keras has
+  # created the model and optimizer state from a standard batch.
+  x, y, sample_weight = keras.utils.unpack_x_y_sample_weight(dataset[0])
+  model._symbolic_build(data_batch=(x, y, sample_weight))  # pylint: disable=protected-access
+
+
+def _masked_mean(
+    values: chex.Array, is_padding_example: jax.Array
+) -> chex.Array:
+  """Averages only the non-padding examples, returning 0 for empty batches."""
+  values = jnp.asarray(values)
+  if values.ndim == 0:
+    return values
+  where = jnp.asarray(~is_padding_example)
+  for _ in range(values.ndim - 1):
+    where = jnp.expand_dims(where, axis=-1)
+  mean = jnp.mean(values, axis=0, where=where)
+  return jnp.where(jnp.any(where, axis=0), mean, jnp.nan_to_num(mean))
 
 
 def _create_fit_fn_with_validation(
@@ -384,6 +627,10 @@ def _create_fit_fn_with_validation(
   ) -> _FitFnReturnType:
     _validate_optimizer(self, self._dp_params)  # pylint: disable=protected-access
     fit_signature = inspect.signature(original_fit_fn)
+    fit_kwargs = _normalize_bound_fit_arguments(fit_signature, *args, **kwargs)
+    use_poisson_sampling_in_fit = (
+        self._dp_params.poisson_sampling_in_fit  # pylint: disable=protected-access
+    )
 
     # batch_size is not set explicitely in the fit() call if the input dataset
     # is already batched. In this case, we assume that the batch sizes are
@@ -401,6 +648,40 @@ def _create_fit_fn_with_validation(
     steps_per_epoch = _get_param(
         fit_signature, 'steps_per_epoch', *args, **kwargs
     )
+    validation_split = (
+        _get_param(fit_signature, 'validation_split', *args, **kwargs) or 0.0
+    )
+    x = _get_param(fit_signature, 'x', *args, **kwargs)
+    y = _get_param(fit_signature, 'y', *args, **kwargs)
+    sample_weight = _get_param(fit_signature, 'sample_weight', *args, **kwargs)
+    validated_train_size = None
+    if use_poisson_sampling_in_fit:
+      if x is None:
+        raise ValueError(
+            'fit() must receive x when'
+            ' DPKerasConfig.poisson_sampling_in_fit is enabled.'
+        )
+      if validation_split:
+        raise ValueError(
+            'validation_split is not supported for DP Keras training because'
+            ' the privacy accountant needs the exact training-set size after'
+            ' any split. Please create the train/validation split explicitly'
+            ' and pass validation_data instead.'
+        )
+      validated_train_size = _tree_batch_size(x)
+      if y is not None and _tree_batch_size(y) != validated_train_size:
+        raise ValueError(
+            'The target data must have the same leading batch dimension as'
+            ' the training inputs.'
+        )
+      if (
+          sample_weight is not None
+          and _tree_batch_size(sample_weight) != validated_train_size
+      ):
+        raise ValueError(
+            'The sample weights must have the same leading batch dimension as'
+            ' the training inputs.'
+        )
 
     # Note accessing self._dp_params is safe because it's added in
     # _add_dp_sgd_attributes, but requires disabling pylint because this
@@ -408,6 +689,7 @@ def _create_fit_fn_with_validation(
     _check_dp_params_aligned_with_fit_args(
         self._dp_params,  # pylint: disable=protected-access
         batch_size,
+        train_size=validated_train_size,
     )
 
     performed_optimizer_steps = (
@@ -437,10 +719,21 @@ def _create_fit_fn_with_validation(
           f' {performed_optimizer_steps + optimizer_steps_to_perform} >'
           f' total_train_steps={self._dp_params.train_steps}.'  # pylint: disable=protected-access
       )
-    return original_fit_fn(
-        *args,
-        **kwargs,
-    )
+    if use_poisson_sampling_in_fit:
+      poisson_dataset = _PoissonSampledTrainingDataset(
+          x,
+          y,
+          sample_weight,
+          dp_params=self._dp_params,  # pylint: disable=protected-access
+          steps_per_epoch=steps_per_epoch
+          or _get_default_steps_per_epoch(validated_train_size, batch_size),
+      )
+      _maybe_symbolically_build_private_model(self, poisson_dataset)
+      fit_kwargs = _prepare_fit_kwargs_for_poisson_dataset(
+          fit_kwargs,
+          poisson_dataset=poisson_dataset,
+      )
+    return original_fit_fn(**fit_kwargs)
 
   return fit_fn_with_validation
 
@@ -448,6 +741,7 @@ def _create_fit_fn_with_validation(
 def _check_dp_params_aligned_with_fit_args(
     dp_params: DPKerasConfig,
     batch_size: int,
+    train_size: int | None = None,
 ) -> None:
   """Checks that the DP parameters are aligned with the fit() arguments."""
   if dp_params.batch_size != batch_size:
@@ -456,6 +750,14 @@ def _check_dp_params_aligned_with_fit_args(
         f' passed to fit(): {dp_params.batch_size=} != {batch_size=}. Please'
         ' make sure that the batch size in the DP parameters is equal to the'
         ' batch size passed to fit().'
+    )
+  if train_size is not None and dp_params.train_size != train_size:
+    raise ValueError(
+        'The train size in the DP parameters is not equal to the size of the'
+        f' training data passed to fit(): {dp_params.train_size=} !='
+        f' {train_size=}. Please make sure that DPKerasConfig.train_size'
+        ' matches the number of training examples available for Poisson'
+        ' sampling.'
     )
 
 
@@ -517,10 +819,16 @@ def _dp_train_step(
       _,
   ) = state
   x, y, sample_weight = keras.utils.unpack_x_y_sample_weight(data)
+  is_padding_example = None
+  if (
+      self._dp_params.poisson_sampling_in_fit  # pylint: disable=protected-access
+      and sample_weight is not None
+  ):
+    is_padding_example = _padding_mask_from_sample_weight(sample_weight)
 
   dp_batch_size = self._dp_params.batch_size  # pylint: disable=protected-access
   actual_batch_size = jax.tree_util.tree_leaves(x)[0].shape[0]
-  if dp_batch_size != actual_batch_size:
+  if is_padding_example is None and dp_batch_size != actual_batch_size:
     # it is ok to throw an exception even though we are in a jit function
     # because the check is based on the static values, i.e. they won't
     # change between invocations, and if the condition is violated, it will
@@ -533,6 +841,8 @@ def _dp_train_step(
         ' data you supplied in the fit() call.'
     )
     raise ValueError(error_message)
+  if is_padding_example is None:
+    is_padding_example = jnp.zeros(actual_batch_size, dtype=jnp.bool_)
 
   (_, aux), grads = _noised_clipped_grads(
       self.compute_loss_and_updates,
@@ -540,6 +850,7 @@ def _dp_train_step(
       state,
       data,
       model=self,
+      is_padding_example=is_padding_example,
   )
   (
       unscaled_loss,
@@ -616,6 +927,8 @@ def _noised_clipped_grads(
     state: _StateType,
     data: _KerasInputsDataType,
     model: keras.Model | None = None,
+    *,
+    is_padding_example: jax.Array | None = None,
 ) -> tuple[tuple[chex.Numeric, _AuxType], chex.ArrayTree]:
   """Computes noised and clipped gradients.
 
@@ -627,6 +940,8 @@ def _noised_clipped_grads(
     data: The data for the model: triple of x, y (can be None), sample_weight
       (can be None).
     model: Optional Keras model used to cache the calibrated noise multiplier.
+    is_padding_example: Optional mask marking padded examples introduced by the
+      Poisson-sampled training wrapper.
 
   Returns:
     (loss, aux), grads
@@ -640,6 +955,12 @@ def _noised_clipped_grads(
   # TODO: b/415360727 - access it and update it by name.
   noise_state = non_trainable_variables[0], ()
   x, y, sample_weight = keras.utils.unpack_x_y_sample_weight(data)
+  if is_padding_example is None:
+    if dp_params.poisson_sampling_in_fit and sample_weight is not None:
+      is_padding_example = _padding_mask_from_sample_weight(sample_weight)
+    else:
+      batch_size = jax.tree.leaves(x)[0].shape[0]
+      is_padding_example = jnp.zeros(batch_size, dtype=jnp.bool_)
 
   clipped_grad_fn = jax_privacy.clipped_grad(
       fun=compute_loss_and_updates_fn,
@@ -661,6 +982,7 @@ def _noised_clipped_grads(
       sample_weight,
       True,  # training=True
       optimizer_variables,
+      is_padding_example=is_padding_example,
   )
 
   noise_multiplier = _resolve_noise_multiplier(dp_params, model)
@@ -671,11 +993,16 @@ def _noised_clipped_grads(
 
   noisy_grads, new_noise_state = privatizer.update(clipped_grad, noise_state)
 
-  loss = per_example_aux.values.mean()
-  unscaled_loss = per_example_aux.aux[0].mean()
+  # Use masked means so padded Poisson examples do not affect the logs.
+  loss = _masked_mean(per_example_aux.values, is_padding_example)
+  unscaled_loss = _masked_mean(per_example_aux.aux[0], is_padding_example)
   y_pred = per_example_aux.aux[1]
   non_trainable_variables = [new_noise_state[0]] + non_trainable_variables[1:]
-  new_metrics = jax.tree.map(lambda x: x.mean(axis=0), per_example_aux.aux[3])
+  # Metrics follow the same masked-mean reduction as the loss values above.
+  new_metrics = jax.tree.map(
+      lambda x: _masked_mean(x, is_padding_example),
+      per_example_aux.aux[3],
+  )
 
   aux = (unscaled_loss, y_pred, non_trainable_variables, new_metrics)
 
@@ -764,8 +1091,14 @@ def _calculate_optimizer_steps_to_perform_in_fit(
 ) -> int:
   """Returns the number of optimizer steps that will be performed by fit."""
   epochs_to_perform = epochs - initial_epoch
-  steps_per_epoch = steps_per_epoch or (train_size // batch_size)
+  steps_per_epoch = steps_per_epoch or _get_default_steps_per_epoch(
+      train_size, batch_size
+  )
   return steps_per_epoch * epochs_to_perform
+
+
+def _get_default_steps_per_epoch(train_size: int, batch_size: int) -> int:
+  return max(1, math.floor(train_size / batch_size))
 
 
 def _get_random_int64() -> np.int64:

--- a/tests/batch_selection_test.py
+++ b/tests/batch_selection_test.py
@@ -453,6 +453,12 @@ class BatchPaddingTest(parameterized.TestCase):
     self.assertEqual(new_indices.size % multiple, 0)
     np.testing.assert_array_equal(new_indices[new_indices != -1], indices)
 
+  def test_pad_to_multiple_of_empty_indices(self):
+    new_indices = batch_selection.pad_to_multiple_of(
+        np.array([], dtype=np.int32), multiple=4
+    )
+    np.testing.assert_array_equal(new_indices, np.array([], dtype=np.int32))
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/tests/keras_api_test.py
+++ b/tests/keras_api_test.py
@@ -297,6 +297,63 @@ class KerasApiTest(parameterized.TestCase):
     ):
       keras_api._validate_optimizer(model, dp_params)
 
+  def test_fit_with_weighted_metrics(self):
+    """Verifies that fit with weighted_metrics works.
+
+    There was once a failure related to weighted_metrics introducing shape
+    mismatches in auxiliary outputs, therefore we've added this test case.
+    """
+    batch_size = 2
+    epochs = 1
+    train_size = 4
+
+    input_dim = 3
+    features = 2
+    classes = 4
+
+    inputs = keras.Input(shape=(input_dim, features), dtype="float32")
+    dense = keras.layers.Dense(classes)(inputs)
+
+    model = keras.Model(
+        inputs=inputs,
+        outputs=dense,
+    )
+
+    # Inputs (x): (train_size, input_dim, features)
+    x = np.zeros((train_size, input_dim, features), dtype=np.float32)
+    # Targets (y): (train_size, input_dim) - per-step class indices
+    y = np.zeros((train_size, input_dim), dtype=np.int32)
+    # Sample weights: (train_size, input_dim) - per-step weights
+    sample_weight = np.ones((train_size, input_dim), dtype=np.float32)
+
+    dp_params = keras_api.DPKerasConfig(
+        epsilon=100.0,
+        delta=1e-5,
+        clipping_norm=1.0,
+        batch_size=batch_size,
+        gradient_accumulation_steps=1,
+        train_steps=epochs * (train_size // batch_size),
+        train_size=train_size,
+        poisson_sampling_in_fit=True,
+        seed=0,
+    )
+
+    model = keras_api.make_private(model, dp_params)
+
+    model.compile(
+        loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+        optimizer=keras.optimizers.Adam(learning_rate=0.01),
+        weighted_metrics=[keras.metrics.SparseCategoricalAccuracy()],
+    )
+
+    history = model.fit(
+        x, y, batch_size=batch_size, epochs=epochs, sample_weight=sample_weight
+    )
+
+    accuracy_key = "sparse_categorical_accuracy"
+    self.assertIn(accuracy_key, history.history)
+    self.assertGreaterEqual(history.history[accuracy_key][-1], 0.0)
+
   def test_poisson_sampled_training_dataset_batches_and_masks_padding(self):
     x = np.arange(24).reshape(12, 2)
     y = np.arange(12)

--- a/tests/keras_api_test.py
+++ b/tests/keras_api_test.py
@@ -74,6 +74,13 @@ class KerasApiTest(parameterized.TestCase):
     with self.assertRaisesRegex(ValueError, "Train size .* must be positive"):
       dataclasses.replace(valid_params, train_size=0)
 
+    # Batch size must not exceed train size.
+    with self.assertRaisesRegex(
+        ValueError,
+        "Batch size 1001 must be less than or equal to train size 1000",
+    ):
+      dataclasses.replace(valid_params, batch_size=1001)
+
     # Invalid noise multiplier
     with self.assertRaisesRegex(
         ValueError, "Noise multiplier .* must be positive"
@@ -100,6 +107,22 @@ class KerasApiTest(parameterized.TestCase):
         "Gradient accumulation steps 0 must be positive",
     ):
       dataclasses.replace(valid_params, gradient_accumulation_steps=0)
+
+    # Invalid microbatch size
+    with self.assertRaisesRegex(
+        ValueError,
+        "Microbatch size 0 must be positive",
+    ):
+      dataclasses.replace(valid_params, microbatch_size=0)
+
+    with self.assertRaisesRegex(
+        ValueError,
+        "Microbatch size 11 must be less than or equal to batch size 10",
+    ):
+      dataclasses.replace(valid_params, microbatch_size=11)
+
+  def test_poisson_sampling_in_fit_defaults_to_disabled(self):
+    self.assertFalse(self._get_params().poisson_sampling_in_fit)
 
   def test_effective_batch_size(self):
     params1 = dataclasses.replace(self._get_params(), batch_size=5)
@@ -274,62 +297,186 @@ class KerasApiTest(parameterized.TestCase):
     ):
       keras_api._validate_optimizer(model, dp_params)
 
-  def test_fit_with_weighted_metrics(self):
-    """Verifies that fit with weighted_metrics works.
-
-    There was once a failure related to weighted_metrics introducing shape
-    mismatches in auxiliary outputs, therefore we've added this test case.
-    """
-    batch_size = 2
-    epochs = 1
-    train_size = 4
-
-    input_dim = 3
-    features = 2
-    classes = 4
-
-    inputs = keras.Input(shape=(input_dim, features), dtype="float32")
-    dense = keras.layers.Dense(classes)(inputs)
-
-    model = keras.Model(
-        inputs=inputs,
-        outputs=dense,
+  def test_poisson_sampled_training_dataset_batches_and_masks_padding(self):
+    x = np.arange(24).reshape(12, 2)
+    y = np.arange(12)
+    sample_weight = np.linspace(1.0, 2.1, 12)
+    dp_params = keras_api.DPKerasConfig(
+        epsilon=1.1,
+        delta=1e-5,
+        clipping_norm=1.0,
+        batch_size=4,
+        gradient_accumulation_steps=1,
+        train_steps=20,
+        train_size=len(x),
+        noise_multiplier=10.0,
+        seed=0,
+    )
+    dataset = keras_api._PoissonSampledTrainingDataset(
+        x,
+        y,
+        sample_weight,
+        dp_params=dp_params,
+        steps_per_epoch=8,
     )
 
-    # Inputs (x): (train_size, input_dim, features)
-    x = np.zeros((train_size, input_dim, features), dtype=np.float32)
-    # Targets (y): (train_size, input_dim) - per-step class indices
-    y = np.zeros((train_size, input_dim), dtype=np.int32)
-    # Sample weights: (train_size, input_dim) - per-step weights
-    sample_weight = np.ones((train_size, input_dim), dtype=np.float32)
+    realized_batch_sizes = []
+    for i, padded_indices in enumerate(dataset._epoch_batches):
+      batch_x, batch_y, batch_sample_weight = (
+          keras.utils.unpack_x_y_sample_weight(dataset[i])
+      )
+      is_padding_example = keras_api._padding_mask_from_sample_weight(
+          batch_sample_weight
+      )
+      valid_positions = padded_indices >= 0
 
+      self.assertEqual(batch_x.shape[0] % dp_params.batch_size, 0)
+      np.testing.assert_array_equal(is_padding_example, ~valid_positions)
+      np.testing.assert_array_equal(
+          batch_x[valid_positions], x[padded_indices[valid_positions]]
+      )
+      np.testing.assert_array_equal(
+          batch_y[valid_positions], y[padded_indices[valid_positions]]
+      )
+      np.testing.assert_array_equal(
+          batch_sample_weight[valid_positions],
+          sample_weight[padded_indices[valid_positions]],
+      )
+      np.testing.assert_array_equal(
+          batch_x[is_padding_example],
+          np.zeros_like(batch_x[is_padding_example]),
+      )
+      np.testing.assert_array_equal(
+          batch_sample_weight[is_padding_example],
+          np.zeros_like(batch_sample_weight[is_padding_example]),
+      )
+      realized_batch_sizes.append(int(valid_positions.sum()))
+
+    self.assertGreater(len(set(realized_batch_sizes)), 1)
+
+  def test_poisson_sampled_training_dataset_generates_mask_sample_weights(self):
+    x = np.arange(12).reshape(6, 2)
     dp_params = keras_api.DPKerasConfig(
-        epsilon=100.0,
+        epsilon=1.1,
+        delta=1e-5,
+        clipping_norm=1.0,
+        batch_size=3,
+        gradient_accumulation_steps=1,
+        train_steps=20,
+        train_size=len(x),
+        noise_multiplier=10.0,
+        seed=0,
+    )
+    dataset = keras_api._PoissonSampledTrainingDataset(
+        x,
+        None,
+        None,
+        dp_params=dp_params,
+        steps_per_epoch=4,
+    )
+
+    _, _, batch_sample_weight = keras.utils.unpack_x_y_sample_weight(dataset[0])
+    is_padding_example = keras_api._padding_mask_from_sample_weight(
+        batch_sample_weight
+    )
+
+    np.testing.assert_array_equal(
+        batch_sample_weight,
+        (~np.asarray(is_padding_example)).astype(np.float32),
+    )
+
+  def test_pad_batch_indices_reifies_empty_poisson_draw(self):
+    padded_indices = keras_api._pad_batch_indices(
+        np.array([], dtype=np.int32), multiple=4
+    )
+
+    np.testing.assert_array_equal(
+        padded_indices, np.array([-1, -1, -1, -1], dtype=np.int32)
+    )
+
+  def test_padding_mask_from_2d_sample_weight(self):
+    sample_weight = np.array(
+        [[1.0, 0.5], [0.0, 0.0], [2.0, 3.0]], dtype=np.float32
+    )
+    padding_mask = keras_api._padding_mask_from_sample_weight(sample_weight)
+
+    np.testing.assert_array_equal(padding_mask, np.array([False, True, False]))
+
+  def test_padding_mask_from_1d_sample_weight(self):
+    sample_weight = np.array([1.0, 0.0, 2.0], dtype=np.float32)
+    padding_mask = keras_api._padding_mask_from_sample_weight(sample_weight)
+
+    np.testing.assert_array_equal(padding_mask, np.array([False, True, False]))
+
+  def test_prepare_fit_kwargs_for_poisson_dataset(self):
+    fit_kwargs = {
+        "x": np.arange(6).reshape(3, 2),
+        "y": np.arange(3),
+        "sample_weight": np.ones(3),
+        "batch_size": 3,
+        "shuffle": True,
+        "validation_split": 0.0,
+        "steps_per_epoch": None,
+        "epochs": 5,
+    }
+    poisson_dataset = object()
+
+    rewritten_kwargs = keras_api._prepare_fit_kwargs_for_poisson_dataset(
+        fit_kwargs,
+        poisson_dataset=poisson_dataset,
+    )
+
+    self.assertEqual(rewritten_kwargs["x"], poisson_dataset)
+    self.assertEqual(rewritten_kwargs["epochs"], 5)
+    self.assertNotIn("y", rewritten_kwargs)
+    self.assertNotIn("sample_weight", rewritten_kwargs)
+    self.assertNotIn("batch_size", rewritten_kwargs)
+    self.assertNotIn("shuffle", rewritten_kwargs)
+    self.assertNotIn("validation_split", rewritten_kwargs)
+    self.assertNotIn("steps_per_epoch", rewritten_kwargs)
+    self.assertEqual(fit_kwargs["x"].shape, (3, 2))
+
+  def test_masked_mean_ignores_padding_examples(self):
+    values = jnp.array([[1.0, 10.0], [3.0, 30.0], [5.0, 50.0]])
+    is_padding_example = jnp.array([False, True, False])
+
+    mean = keras_api._masked_mean(values, is_padding_example)
+
+    np.testing.assert_allclose(mean, np.array([3.0, 30.0]))
+
+  def test_masked_mean_returns_zero_for_all_padding(self):
+    values = jnp.array([[1.0, 10.0], [3.0, 30.0]])
+    is_padding_example = jnp.array([True, True])
+
+    mean = keras_api._masked_mean(values, is_padding_example)
+
+    np.testing.assert_allclose(mean, np.array([0.0, 0.0]))
+
+  def test_dp_training_e2e_work(self):
+    np.random.seed(42)
+    train_size = 200
+    batch_size = 100
+    epochs = 5
+    train_steps = 10  # 5 * (200 / 100)
+    x, y = np.random.uniform(0, 1, (train_size, 4)), np.random.uniform(
+        0, 1, train_size
+    )
+    model = keras.Sequential([keras.Input(shape=(4,)), keras.layers.Dense(1)])
+    dp_params = keras_api.DPKerasConfig(
+        epsilon=1.1,
         delta=1e-5,
         clipping_norm=1.0,
         batch_size=batch_size,
         gradient_accumulation_steps=1,
-        train_steps=epochs * (train_size // batch_size),
+        train_steps=train_steps,
         train_size=train_size,
+        poisson_sampling_in_fit=True,
+        seed=0,
     )
-
     model = keras_api.make_private(model, dp_params)
-
-    model.compile(
-        loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
-        optimizer=keras.optimizers.Adam(learning_rate=0.01),
-        weighted_metrics=[keras.metrics.SparseCategoricalAccuracy()],
-    )
-
-    # Act
-    history = model.fit(
-        x, y, batch_size=batch_size, epochs=epochs, sample_weight=sample_weight
-    )
-
-    # Assert
-    accuracy_key = "sparse_categorical_accuracy"
-    self.assertIn(accuracy_key, history.history)
-    self.assertGreaterEqual(history.history[accuracy_key][-1], 0.0)
+    model.compile(loss="mse", optimizer="adam")
+    model.fit(x, y, epochs=epochs, batch_size=batch_size)  # pylint: disable=not-callable
+    self.assertAlmostEqual(model.evaluate(x, y), 2, delta=2)
 
   def test_dp_training_exceeds_privacy_budget_raises_error(self):
     train_size = 200
@@ -347,6 +494,7 @@ class KerasApiTest(parameterized.TestCase):
         gradient_accumulation_steps=1,
         train_steps=train_steps,
         train_size=train_size,
+        seed=0,
     )
     model = keras_api.make_private(model, dp_params)
     model.compile(loss="mse", optimizer="adam")
@@ -386,6 +534,7 @@ class KerasApiTest(parameterized.TestCase):
         clipping_norm=1.0,
         train_steps=train_steps,
         train_size=train_size,
+        seed=0,
     )
     x, y = np.random.uniform(0, 1, (train_size, 4)), np.random.uniform(
         0, 1, train_size
@@ -439,6 +588,7 @@ class KerasApiTest(parameterized.TestCase):
         clipping_norm=1.0,
         train_steps=28,
         train_size=200,
+        seed=0,
     )
     model = keras_api.make_private(model, dp_params)
     model.compile()
@@ -449,39 +599,113 @@ class KerasApiTest(parameterized.TestCase):
     ):
       model.fit(batch_size=101)  # pylint: disable=not-callable
 
-  @parameterized.named_parameters(
-      ("plain arg", np.zeros((101, 4)), np.zeros((101,))),
-      ("tuple", (np.zeros((101, 4)),), np.zeros((101,))),
-      ("list", [np.zeros((101, 4))], np.zeros((101,))),
-      ("dict", {"x": np.zeros((101, 4))}, np.zeros((101,))),
-  )
-  def test_fit_raises_error_when_dp_batch_size_not_equal_to_actual_data_batch_size(  # pylint: disable=line-too-long
-      self, batched_x, batched_y
-  ):
+  def test_fit_rejects_non_random_access_training_data(self):
     model = keras.Sequential([keras.Input(shape=(4,)), keras.layers.Dense(1)])
-    dp_batch_size = 100  # actual batch size is 101
     dp_params = keras_api.DPKerasConfig(
-        batch_size=dp_batch_size,
+        batch_size=100,
         gradient_accumulation_steps=1,
         epsilon=1.1,
         delta=1e-5,
         clipping_norm=1.0,
         train_steps=28,
         train_size=200,
+        poisson_sampling_in_fit=True,
+        seed=0,
     )
     model = keras_api.make_private(model, dp_params)
 
     def data_generator():
       while True:
-        yield batched_x, batched_y
+        yield np.zeros((100, 4)), np.zeros((100,))
 
     model.compile()
     with self.assertRaisesRegex(
         ValueError,
-        "The batch size in the DP parameters is not equal to the batch size of"
-        " the actual data",
+        "random-access array-like inputs",
     ):
       model.fit(data_generator())  # pylint: disable=not-callable
+
+  def test_fit_allows_generator_when_poisson_sampling_in_fit_disabled(self):
+    model = keras.Sequential([keras.Input(shape=(4,)), keras.layers.Dense(1)])
+    dp_params = keras_api.DPKerasConfig(
+        batch_size=100,
+        gradient_accumulation_steps=1,
+        epsilon=1.1,
+        delta=1e-5,
+        clipping_norm=1.0,
+        train_steps=2,
+        train_size=200,
+        seed=0,
+    )
+    model = keras_api.make_private(model, dp_params)
+
+    def data_generator():
+      while True:
+        yield np.zeros((100, 4)), np.zeros((100,))
+
+    model.compile(loss="mse", optimizer="adam")
+    history = model.fit(  # pylint: disable=not-callable
+        data_generator(),
+        steps_per_epoch=1,
+        epochs=1,
+    )
+
+    self.assertIn("loss", history.history)
+
+  def test_fit_rejects_train_size_mismatch(self):
+    train_size = 200
+    x, y = np.random.uniform(0, 1, (train_size, 4)), np.random.uniform(
+        0, 1, train_size
+    )
+    model = keras.Sequential([keras.Input(shape=(4,)), keras.layers.Dense(1)])
+    dp_params = keras_api.DPKerasConfig(
+        batch_size=100,
+        gradient_accumulation_steps=1,
+        epsilon=1.1,
+        delta=1e-5,
+        clipping_norm=1.0,
+        train_steps=28,
+        train_size=train_size - 1,
+        poisson_sampling_in_fit=True,
+        seed=0,
+    )
+    model = keras_api.make_private(model, dp_params)
+    model.compile(loss="mse", optimizer="adam")
+
+    with self.assertRaisesRegex(
+        ValueError,
+        "The train size in the DP parameters is not equal to the size of the"
+        " training data passed to fit",
+    ):
+      model.fit(x, y, batch_size=100)  # pylint: disable=not-callable
+
+  def test_fit_rejects_validation_split(self):
+    train_size = 200
+    x, y = np.random.uniform(0, 1, (train_size, 4)), np.random.uniform(
+        0, 1, train_size
+    )
+    model = keras.Sequential([keras.Input(shape=(4,)), keras.layers.Dense(1)])
+    dp_params = keras_api.DPKerasConfig(
+        batch_size=100,
+        gradient_accumulation_steps=1,
+        epsilon=1.1,
+        delta=1e-5,
+        clipping_norm=1.0,
+        train_steps=28,
+        train_size=train_size,
+        poisson_sampling_in_fit=True,
+        seed=0,
+    )
+    model = keras_api.make_private(model, dp_params)
+    model.compile(loss="mse", optimizer="adam")
+
+    with self.assertRaisesRegex(
+        ValueError,
+        "validation_split is not supported for DP Keras training",
+    ):
+      model.fit(  # pylint: disable=not-callable
+          x, y, batch_size=100, validation_split=0.1
+      )
 
   def test_train_step_call_noised_clipped_grads(self):
     train_size = 200
@@ -500,6 +724,8 @@ class KerasApiTest(parameterized.TestCase):
         gradient_accumulation_steps=1,
         train_steps=train_steps,
         train_size=train_size,
+        poisson_sampling_in_fit=True,
+        seed=0,
     )
     model = keras_api.make_private(model, dp_params)
     model.compile(loss="mse", optimizer="adam")


### PR DESCRIPTION
## What this PR changes

This PR updates the Keras DP path so Poisson sampling can be done directly inside `fit()` without breaking the existing API.

The main change is an opt-in flag, `DPKerasConfig.poisson_sampling_in_fit`, which defaults to `False`. When it is enabled, the wrapper builds a Poisson-sampled `keras.utils.PyDataset` from random-access per-example arrays, validates the input sizes against the DP config, and rejects `validation_split` because the accountant needs the exact training-set size.

## Main changes

- Add `poisson_sampling_in_fit` to `DPKerasConfig`, defaulting to `False` for backward compatibility.
- Build Poisson-sampled batches internally only when that flag is enabled.
- Validate random-access array inputs and ensure `x`, `y`, and `sample_weight` agree on batch size in the Poisson-in-fit path.
- Represent padded examples through zero sample weights and derive the padding mask from `sample_weight` inside the DP training path.
- Update the Keras example and docs to show the opt-in Poisson path explicitly.
- Expand Keras tests around batch construction, padding, validation errors, and fit-argument rewriting.
- Add the empty-input padding edge case coverage in `batch_selection`.

## Why this shape

The goal here is to make the privacy-sensitive Poisson-sampling path available directly in the Keras wrapper while keeping the older workflows intact. Users who already batch or sample outside the wrapper can keep doing that. Users who want the wrapper to own batch formation can enable the flag and get a path whose sampling behavior matches the DP accounting assumptions.

## Verification

I ran the following locally in Python 3.11:

- `KERAS_BACKEND=jax python -m pytest tests/keras_api_test.py -q`
- `python -m pytest tests/batch_selection_test.py -q -k 'pad_to_multiple_of'`
- `python -m pyink --check --diff jax_privacy/keras_api.py tests/keras_api_test.py`
- `python -m pylint --rcfile=.pylintrc jax_privacy/keras_api.py`
