### PR TITLE
Add BandInvMF and BISR support to Toeplitz matrix factorizations

### DIFF
--- a/examples/dpmf_strategy_optimization.py
+++ b/examples/dpmf_strategy_optimization.py
@@ -50,6 +50,8 @@ _STRATEGY = flags.DEFINE_enum(
         'dense',
         'banded',
         'banded-toeplitz',
+        'banded-inverse-toeplitz',
+        'bisr',
         'blt',
         'banded-sqrt',
         'normalized-banded-toeplitz',
@@ -74,6 +76,18 @@ _OBJECTIVE = flags.DEFINE_enum(
     ['mean', 'max'],
     'Objective to optimize.',
 )
+_ALPHA = flags.DEFINE_float(
+    'alpha',
+    1.0,
+    'First root of the Toeplitz SGD workload recurrence. The default value'
+    ' recovers the prefix-sum workload.',
+)
+_BETA = flags.DEFINE_float(
+    'beta',
+    0.0,
+    'Second root of the Toeplitz SGD workload recurrence. The default value'
+    ' recovers the prefix-sum workload.',
+)
 
 
 def optimize_strategy(
@@ -82,11 +96,14 @@ def optimize_strategy(
     n: int,
     participations: int = 1,
     objective: str = 'mean',
+    alpha: float = 1.0,
+    beta: float = 0.0,
 ):
   """Compute matrix factorization+error metrics for the given configuration."""
   sep = n // participations
   t0 = time.time()
   loss = None
+  workload_coef = toeplitz.sgd_workload_coef(n=n, alpha=alpha, beta=beta)
 
   if objective not in ['mean', 'max']:
     raise ValueError(f'Unknown objective {objective}')
@@ -103,6 +120,51 @@ def optimize_strategy(
       )
       pqe = toeplitz.per_query_error(strategy_coef=strategy_coef, n=n)
       loss = reduction_fn(pqe) * sensitivity_squared
+
+    case 'banded-inverse-toeplitz':
+      noising_coef = toeplitz.optimize_banded_inverse_toeplitz(
+          n=n,
+          bands=sep,
+          min_sep=sep,
+          max_participations=participations,
+          workload_coef=workload_coef,
+          workload_inverse_coef=toeplitz.sgd_workload_inverse_coef(
+              alpha=alpha, beta=beta
+          ),
+          alpha=alpha,
+          beta=beta,
+          reduction_fn=reduction_fn,
+          max_optimizer_steps=1000,
+      )
+      sensitivity_value = toeplitz.compute_banded_inverse_sensitivity(
+          noising_coef,
+          min_sep=sep,
+          max_participations=participations,
+          n=n,
+      )
+      pqe = toeplitz.per_query_error(
+          noising_coef=noising_coef,
+          n=n,
+          workload_coef=workload_coef,
+      )
+      loss = reduction_fn(pqe) * sensitivity_value**2
+
+    case 'bisr':
+      noising_coef = toeplitz.compute_banded_inverse_square_root(
+          sep, alpha=alpha, beta=beta
+      )
+      sensitivity_value = toeplitz.compute_banded_inverse_sensitivity(
+          noising_coef,
+          min_sep=sep,
+          max_participations=participations,
+          n=n,
+      )
+      pqe = toeplitz.per_query_error(
+          noising_coef=noising_coef,
+          n=n,
+          workload_coef=workload_coef,
+      )
+      loss = reduction_fn(pqe) * sensitivity_value**2
 
     case 'normalized-banded-toeplitz':
       # https://arxiv.org/abs/2405.15913
@@ -187,6 +249,8 @@ def main(_) -> None:
       n=_ITERATIONS.value,
       participations=_PARTICIPATIONS.value,
       objective=_OBJECTIVE.value,
+      alpha=_ALPHA.value,
+      beta=_BETA.value,
   )
 
 

--- a/jax_privacy/matrix_factorization/README.md
+++ b/jax_privacy/matrix_factorization/README.md
@@ -97,6 +97,12 @@ Implemented in [`toeplitz.py`](toeplitz.py). Structure $$C \in R^{n \times n}$$
 lower-triangular Toeplitz matrix. Parameters n, the size of $$C$$ coef, the
 non-zero Toeplitz coefficients of $$C$$. See [BandMF24].
 
+This module also supports inverse-Toeplitz variants where the noising matrix
+$$C^{-1}$$ is parameterized directly. The explicit inverse-square-root
+construction is exposed as BISR, while the numerically optimized inverse-coef
+variant is exposed as BandInvMF. For a concrete usage example of both, see
+[`examples/dpmf_strategy_optimization.py`](../../examples/dpmf_strategy_optimization.py).
+
 TODO: b/329444015 - Markdown example where n = 4 and coef = [1, 0.5]) for
 example.
 
@@ -141,6 +147,9 @@ see the [LTI24].
 1.  **[UseBLTs24]** *A Hassle-free Algorithm for Private Learning in Practice:
     Don't Use Tree Aggregation, Use BLTs.* EMNLP Industry Track 2024
 
+1.  **[BISR26]** *Back to Square Roots: An Optimal Bound on the Matrix
+    Factorization Error for Multi-Epoch Differentially Private SGD.* ICLR 2026.
+
 [SingleEpoch22]: https://arxiv.org/abs/2202.08312
 [FHU23]: https://arxiv.org/abs/2202.11205
 [MultiEpoch23]: https://arxiv.org/abs/2211.06530
@@ -150,3 +159,4 @@ see the [LTI24].
 [BandedSqrt24]: https://arxiv.org/abs/2405.13763
 [BandMF24]: https://arxiv.org/abs/2405.15913
 [UseBLTs24]: https://arxiv.org/abs/2408.08868
+[BISR26]: https://arxiv.org/abs/2505.12128

--- a/jax_privacy/matrix_factorization/toeplitz.py
+++ b/jax_privacy/matrix_factorization/toeplitz.py
@@ -172,6 +172,23 @@ def optimal_max_error_noising_coefs(n: int) -> jax.Array:
   return c.at[1:n].subtract(c[:-1])
 
 
+def sgd_workload_inverse_coef(
+    alpha: float = 1.0, beta: float = 0.0
+) -> jax.Array:
+  """Returns Toeplitz coefficients of the inverse SGD workload matrix."""
+  return jnp.array([1.0, -(alpha + beta), alpha * beta])
+
+
+def sgd_workload_coef(
+    n: int, alpha: float = 1.0, beta: float = 0.0
+) -> jax.Array:
+  """Returns Toeplitz coefficients of the SGD workload matrix."""
+  k = jnp.arange(n, dtype=jnp.result_type(alpha, beta, 1.0))
+  if alpha == beta:
+    return (k + 1) * alpha**k
+  return (alpha ** (k + 1) - beta ** (k + 1)) / (alpha - beta)
+
+
 def materialize_lower_triangular(
     coef: jax.Array, n: int | None = None
 ) -> jax.Array:
@@ -298,6 +315,35 @@ def inverse_coef(coef: jax.Array, n: int | None = None) -> jax.Array:
   return solve_banded(coef, jnp.zeros(n).at[0].set(1))
 
 
+def _square_root_coef(coef: jax.Array, n: int | None = None) -> jax.Array:
+  """Returns coefficients of a Toeplitz square root."""
+  coef, n = _reconcile(coef, n)
+  coef = pad_coefs_to_n(coef, n)
+  if coef[0] <= 0:
+    raise ValueError('Expected coef[0] to be positive.')
+  result = jnp.zeros_like(coef)
+  result = result.at[0].set(jnp.sqrt(coef[0]))
+  for k in range(1, n):
+    correction = jnp.dot(result[1:k], result[1:k][::-1])
+    result = result.at[k].set((coef[k] - correction) / (2 * result[0]))
+  return result
+
+
+def compute_banded_inverse_square_root(
+    bands: int,
+    *,
+    workload_inverse_coef: jax.Array | None = None,
+    alpha: float = 1.0,
+    beta: float = 0.0,
+) -> jax.Array:
+  """Returns BISR noising coefficients for a Toeplitz SGD workload."""
+  if bands <= 0:
+    raise ValueError(f'Expected bands > 0, found {bands}.')
+  if workload_inverse_coef is None:
+    workload_inverse_coef = sgd_workload_inverse_coef(alpha=alpha, beta=beta)
+  return _square_root_coef(workload_inverse_coef, n=bands)
+
+
 def sensitivity_squared(coef: jax.Array, n: int | None = None) -> jax.Array:
   """Sensitivity^2 under single participation."""
   coef, _ = _reconcile(coef, n)
@@ -374,6 +420,36 @@ def minsep_sensitivity_squared(
       vector[min_sep * k :] - vector[: -min_sep * k]
   )
   return vector[:n] @ vector[:n]
+
+
+def compute_banded_inverse_sensitivity(
+    noising_coef: jax.Array,
+    min_sep: int,
+    max_participations: int | None = None,
+    *,
+    n: int | None = None,
+    use_x_sensitivity_upper_bound: bool = False,
+) -> jax.Array:
+  """Returns a safe sensitivity upper bound for inverse Toeplitz factors."""
+  strategy_coef = inverse_coef(noising_coef, n=n)
+  if use_x_sensitivity_upper_bound:
+    strategy_matrix = materialize_lower_triangular(strategy_coef, n=n)
+    gram = strategy_matrix.T @ strategy_matrix
+    return jnp.array(
+        sensitivity.get_min_sep_sensitivity_upper_bound_for_X(
+            gram, min_sep=min_sep, max_participations=max_participations
+        )
+    )
+  monotone_upper_bound = jax.lax.cummax(jnp.abs(strategy_coef), reverse=True)
+  return jnp.sqrt(
+      minsep_sensitivity_squared(
+          monotone_upper_bound,
+          min_sep=min_sep,
+          max_participations=max_participations,
+          n=n,
+          skip_checks=True,
+      )
+  )
 
 
 def per_query_error(
@@ -471,6 +547,38 @@ def loss(
   return error * sens_squared
 
 
+def inverse_loss(
+    noising_coef: jax.Array,
+    *,
+    min_sep: int,
+    max_participations: int | None = None,
+    n: int | None = None,
+    workload_coef: jax.Array | None = None,
+    reduction_fn: Callable[[jax.Array], jax.Array] = jnp.mean,
+    use_x_sensitivity_upper_bound: bool = False,
+) -> jax.Array:
+  """Error of C^{-1} on a Toeplitz workload under repeated participation."""
+  if reduction_fn is jnp.max:
+    reduction_fn = lambda v: v[-1]
+  noising_coef, n = _reconcile(noising_coef, n)
+  error = reduction_fn(
+      per_query_error(
+          noising_coef=noising_coef,
+          n=n,
+          workload_coef=workload_coef,
+          skip_checks=True,
+      )
+  )
+  sensitivity_value = compute_banded_inverse_sensitivity(
+      noising_coef,
+      min_sep=min_sep,
+      max_participations=max_participations,
+      n=n,
+      use_x_sensitivity_upper_bound=use_x_sensitivity_upper_bound,
+  )
+  return error * sensitivity_value**2
+
+
 def optimize_banded_toeplitz(
     n: int,
     bands: int,
@@ -518,6 +626,52 @@ def optimize_banded_toeplitz(
       loss_fn, strategy_coef, max_optimizer_steps=max_optimizer_steps
   )
   return params / jnp.linalg.norm(params)
+
+
+def optimize_banded_inverse_toeplitz(
+    n: int,
+    bands: int,
+    *,
+    min_sep: int,
+    max_participations: int | None = None,
+    noising_coef: jax.Array | None = None,
+    workload_coef: jax.Array | None = None,
+    workload_inverse_coef: jax.Array | None = None,
+    alpha: float = 1.0,
+    beta: float = 0.0,
+    max_optimizer_steps: int = 250,
+    reduction_fn: Callable[[jax.Array], jax.Array] = jnp.mean,
+    use_x_sensitivity_upper_bound: bool = False,
+) -> jax.Array:
+  """Optimize over banded inverse Toeplitz matrices for a Toeplitz workload."""
+  if noising_coef is None:
+    if workload_inverse_coef is not None or workload_coef is None:
+      noising_coef = compute_banded_inverse_square_root(
+          bands,
+          workload_inverse_coef=workload_inverse_coef,
+          alpha=alpha,
+          beta=beta,
+      )
+    else:
+      noising_coef = optimal_max_error_noising_coefs(bands)
+  if noising_coef.shape[0] != bands:
+    raise ValueError(f'{noising_coef.shape=} != {bands=}')
+  if workload_coef is None:
+    workload_coef = sgd_workload_coef(n=n, alpha=alpha, beta=beta)
+  objective = functools.partial(
+      inverse_loss,
+      n=n,
+      min_sep=min_sep,
+      max_participations=max_participations,
+      workload_coef=workload_coef,
+      reduction_fn=reduction_fn,
+      use_x_sensitivity_upper_bound=use_x_sensitivity_upper_bound,
+  )
+  return optimization.optimize(
+      objective,
+      noising_coef,
+      max_optimizer_steps=max_optimizer_steps,
+  )
 
 
 def _factors(n):

--- a/tests/matrix_factorization/toeplitz_test.py
+++ b/tests/matrix_factorization/toeplitz_test.py
@@ -374,8 +374,8 @@ class ToeplitzErrorTest(parameterized.TestCase):
     np.testing.assert_allclose(toeplitz.sgd_workload_coef(8), jnp.ones(8))
 
   @parameterized.named_parameters(
-      ('prefix', jnp.array([1.0, -1.0]), 8),
-      ('momentum_like', jnp.array([1.0, -1.0, 0.09]), 8),
+      ('prefix', np.array([1.0, -1.0]), 8),
+      ('momentum_like', np.array([1.0, -1.0, 0.09]), 8),
   )
   def test_banded_inverse_square_root_matches_inverse_workload(self, x, n):
     inv_sqrt = toeplitz.compute_banded_inverse_square_root(

--- a/tests/matrix_factorization/toeplitz_test.py
+++ b/tests/matrix_factorization/toeplitz_test.py
@@ -350,8 +350,64 @@ def _per_query_error(
   return dense.per_query_error(strategy_matrix=C, workload_matrix=A)
 
 
+def _inverse_mean_loss(
+    c_inv_coef: jnp.ndarray,
+    *,
+    n: int,
+    min_sep: int,
+    max_participations: int,
+    workload_coef: jax.Array | None = None,
+) -> jnp.ndarray:
+  return toeplitz.inverse_loss(
+      c_inv_coef,
+      n=n,
+      min_sep=min_sep,
+      max_participations=max_participations,
+      workload_coef=workload_coef,
+      reduction_fn=jnp.mean,
+  )
+
+
 class ToeplitzErrorTest(parameterized.TestCase):
 
+  def test_sgd_workload_coef_prefix_sum(self):
+    np.testing.assert_allclose(toeplitz.sgd_workload_coef(8), jnp.ones(8))
+
+  @parameterized.named_parameters(
+      ('prefix', jnp.array([1.0, -1.0]), 8),
+      ('momentum_like', jnp.array([1.0, -1.0, 0.09]), 8),
+  )
+  def test_banded_inverse_square_root_matches_inverse_workload(self, x, n):
+    inv_sqrt = toeplitz.compute_banded_inverse_square_root(
+        n, workload_inverse_coef=x
+    )
+    expected = toeplitz.pad_coefs_to_n(x, n)
+    actual = toeplitz.multiply(inv_sqrt, inv_sqrt, n=n)
+    np.testing.assert_allclose(actual, expected, atol=1e-12)
+
+  def test_banded_inverse_square_root_prefix_matches_fhu_inverse(self):
+    expected = toeplitz.optimal_max_error_noising_coefs(8)
+    actual = toeplitz.compute_banded_inverse_square_root(8)
+    np.testing.assert_allclose(actual, expected)
+
+  def test_compute_banded_inverse_sensitivity_prefix(self):
+    noising_coef = toeplitz.compute_banded_inverse_square_root(6)
+    sensitivity_value = toeplitz.compute_banded_inverse_sensitivity(
+        noising_coef,
+        min_sep=2,
+        max_participations=3,
+        n=12,
+    )
+    strategy_coef = toeplitz.inverse_coef(noising_coef, n=12)
+    expected = jnp.sqrt(
+        toeplitz.minsep_sensitivity_squared(
+            strategy_coef,
+            min_sep=2,
+            max_participations=3,
+            n=12,
+        )
+    )
+    np.testing.assert_allclose(sensitivity_value, expected)
   @hypothesis.given(
       name_coef_n_tuple=st.sampled_from(NAMED_C_MATRIX_PARAMS),
       workload=st.sampled_from(
@@ -460,6 +516,35 @@ class ToeplitzOptimizationTest(parameterized.TestCase):
     self.assertLessEqual(
         toeplitz.loss(strategy_coef=coef2, n=16),
         toeplitz.loss(strategy_coef=coef1, n=16),
+    )
+
+  def test_optimize_banded_inverse_toeplitz_improves_over_bisr_init(self):
+    n = 16
+    bands = 3
+    min_sep = 4
+    max_participations = 4
+    init = toeplitz.compute_banded_inverse_square_root(bands)
+    optimized = toeplitz.optimize_banded_inverse_toeplitz(
+        n=n,
+        bands=bands,
+        min_sep=min_sep,
+        max_participations=max_participations,
+        noising_coef=init,
+        max_optimizer_steps=25,
+    )
+    self.assertLessEqual(
+        _inverse_mean_loss(
+            optimized,
+            n=n,
+            min_sep=min_sep,
+            max_participations=max_participations,
+        ),
+        _inverse_mean_loss(
+            init,
+            n=n,
+            min_sep=min_sep,
+            max_participations=max_participations,
+        ),
     )
 
 

--- a/tests/matrix_factorization/toeplitz_test.py
+++ b/tests/matrix_factorization/toeplitz_test.py
@@ -408,6 +408,7 @@ class ToeplitzErrorTest(parameterized.TestCase):
         )
     )
     np.testing.assert_allclose(sensitivity_value, expected)
+
   @hypothesis.given(
       name_coef_n_tuple=st.sampled_from(NAMED_C_MATRIX_PARAMS),
       workload=st.sampled_from(


### PR DESCRIPTION
## Summary

This PR adds BandInvMF / BISR support to the existing Toeplitz matrix-factorization implementation and keeps the change entirely inside `jax_privacy.matrix_factorization.toeplitz`, per the guidance on issue #202.

The new functionality covers:
- explicit BISR initialization via inverse square roots of Toeplitz SGD workloads
- direct optimization of banded inverse Toeplitz coefficients (BandInvMF)
- a safe default inverse-sensitivity bound based on the monotone upper-envelope of `inverse_coef(noising_coef)`
- optional tighter sensitivity estimation via `sensitivity.get_min_sep_sensitivity_upper_bound_for_X`
- example usage in `examples/dpmf_strategy_optimization.py`

## What changed

- Added Toeplitz helpers for SGD workload coefficients and inverse coefficients.
- Added `compute_banded_inverse_square_root(...)` for the explicit BISR construction.
- Added `compute_banded_inverse_sensitivity(...)` for repeated-participation sensitivity of inverse-Toeplitz mechanisms.
- Added `inverse_loss(...)`, `inverse_mean_loss`, and `inverse_max_loss`.
- Added `optimize_banded_inverse_toeplitz(...)` for direct inverse-coefficient optimization.
- Extended `examples/dpmf_strategy_optimization.py` with `bisr` and `banded-inverse-toeplitz` strategies plus `--alpha` / `--beta` flags.
- Added Toeplitz tests covering the new workload helpers, BISR construction, inverse sensitivity, and inverse optimization.
- Added a short README update under `matrix_factorization/README.md` describing the new inverse-Toeplitz variants and where to find example usage.

## Design choices

- The implementation stays in `toeplitz.py` instead of introducing a new module.
- The default sensitivity path is the safe monotone-upper-bound route:
  - compute `strategy_coef = inverse_coef(noising_coef, n)`
  - replace it by `cummax(abs(strategy_coef), reverse=True)`
  - call `minsep_sensitivity_squared(..., skip_checks=True)` on that sequence
- The optional `use_x_sensitivity_upper_bound=True` path uses the Gram-matrix upper bound from `sensitivity.py` when a tighter bound is preferred.
- The default `(alpha=1.0, beta=0.0)` workload recovers the prefix-sum / FHU setting.

## Verification

I ran the following locally in Python 3.11:

- `python -m pytest tests/matrix_factorization/toeplitz_test.py -q`
- `HYPOTHESIS_PROFILE=dpftrl_default python -m pytest tests/matrix_factorization -q --ignore=tests/matrix_factorization/buffered_toeplitz_test.py`
- `python -m pyink --check --diff jax_privacy/matrix_factorization/toeplitz.py tests/matrix_factorization/toeplitz_test.py examples/dpmf_strategy_optimization.py`
- `python -m pylint --rcfile=.pylintrc jax_privacy/matrix_factorization/toeplitz.py examples/dpmf_strategy_optimization.py`
- `python examples/dpmf_strategy_optimization.py --strategy=bisr --iterations=16 --participations=4 --objective=mean`
- `python examples/dpmf_strategy_optimization.py --strategy=banded-inverse-toeplitz --iterations=16 --participations=4 --objective=mean`

Issue: #202
