### PR TITLE
Add banded-inverse methods

### DIFF
--- a/examples/dpmf_strategy_optimization.py
+++ b/examples/dpmf_strategy_optimization.py
@@ -108,20 +108,11 @@ def optimize_strategy(
 
     case 'banded-inverse-toeplitz':
       # https://arxiv.org/pdf/2505.12128
-      weight_decay = 1.0
-      momentum = 0.0
-      workload_coef = toeplitz.multiply(
-          weight_decay ** jnp.arange(n),
-          momentum ** jnp.arange(n),
-          n=n,
-          skip_checks=True,
-      )
       noising_coef = toeplitz.optimize_banded_inverse_toeplitz(
           n=n,
           min_sep=sep,
           num_bands=sep,
-          weight_decay=weight_decay,
-          momentum=momentum,
+          max_participations=participations,
           max_optimizer_steps=1000,
           reduction_fn=reduction_fn,
       )
@@ -132,7 +123,7 @@ def optimize_strategy(
           max_participations=participations,
       )
       pqe = toeplitz.per_query_error(
-          noising_coef=noising_coef, n=n, workload_coef=workload_coef
+          noising_coef=noising_coef, n=n, workload_coef=jnp.ones(n)
       )
       loss = reduction_fn(pqe) * sensitivity_squared
 
@@ -172,17 +163,7 @@ def optimize_strategy(
 
     case 'banded-inverse-sqrt':
       # https://arxiv.org/pdf/2505.12128
-      weight_decay = 1.0
-      momentum = 0.0
-      workload_coef = toeplitz.multiply(
-          weight_decay ** jnp.arange(n),
-          momentum ** jnp.arange(n),
-          n=n,
-          skip_checks=True,
-      )
-      noising_coef = toeplitz.banded_inverse_square_root_noising_coefs(
-          sep, weight_decay=weight_decay, momentum=momentum
-      )
+      noising_coef = toeplitz.banded_inverse_square_root_noising_coefs(sep)
       sensitivity_squared = toeplitz.compute_banded_inverse_sensitivity_squared(
           n=n,
           noising_coef=noising_coef,
@@ -190,7 +171,7 @@ def optimize_strategy(
           max_participations=participations,
       )
       pqe = toeplitz.per_query_error(
-          noising_coef=noising_coef, n=n, workload_coef=workload_coef
+          noising_coef=noising_coef, n=n, workload_coef=jnp.ones(n)
       )
       loss = reduction_fn(pqe) * sensitivity_squared
 

--- a/examples/dpmf_strategy_optimization.py
+++ b/examples/dpmf_strategy_optimization.py
@@ -130,7 +130,7 @@ def optimize_strategy(
           noising_coef=noising_coef,
           min_sep=sep,
           max_participations=participations,
-      ) 
+      )
       pqe = toeplitz.per_query_error(
           noising_coef=noising_coef, n=n, workload_coef=workload_coef
       )
@@ -164,7 +164,6 @@ def optimize_strategy(
       # https://arxiv.org/abs/2202.11205
       # https://arxiv.org/abs/2405.13763
       strategy_coef = toeplitz.optimal_max_error_strategy_coefs(sep)
-      strategy_coef = jnp.concatenate([strategy_coef, jnp.zeros(n - sep)])
       sensitivity_squared = toeplitz.minsep_sensitivity_squared(
           strategy_coef, min_sep=sep, max_participations=participations
       )

--- a/examples/dpmf_strategy_optimization.py
+++ b/examples/dpmf_strategy_optimization.py
@@ -50,8 +50,10 @@ _STRATEGY = flags.DEFINE_enum(
         'dense',
         'banded',
         'banded-toeplitz',
+        'banded-inverse-toeplitz',
         'blt',
         'banded-sqrt',
+        'banded-inverse-sqrt',
         'normalized-banded-toeplitz',
     ],
     'Strategy class to optimize over.  See code for details.',
@@ -104,6 +106,35 @@ def optimize_strategy(
       pqe = toeplitz.per_query_error(strategy_coef=strategy_coef, n=n)
       loss = reduction_fn(pqe) * sensitivity_squared
 
+    case 'banded-inverse-toeplitz':
+      # https://arxiv.org/pdf/2505.12128
+      weight_decay = 1.0
+      momentum = 0.0
+      workload_coef = toeplitz.multiply(
+          weight_decay**jnp.arange(n),
+          momentum**jnp.arange(n),
+          n=n,
+          skip_checks=True,
+      )
+      noising_coef = toeplitz.optimize_banded_inverse_toeplitz(
+          n=n,
+          min_sep=sep,
+          num_bands=sep,
+          weight_decay=weight_decay,
+          momentum=momentum,
+          max_optimizer_steps=10,
+      )
+      sensitivity_squared = toeplitz.compute_banded_inverse_sensitivity(
+          n=n,
+          noising_coef=noising_coef,
+          min_sep=sep,
+          max_participations=participations,
+      ) ** 2
+      pqe = toeplitz.per_query_error(
+          noising_coef=noising_coef, n=n, workload_coef=workload_coef
+      )
+      loss = reduction_fn(pqe) * sensitivity_squared
+
     case 'normalized-banded-toeplitz':
       # https://arxiv.org/abs/2405.15913
       def loss_fn(coef):  # pylint: disable=function-redefined
@@ -136,6 +167,30 @@ def optimize_strategy(
           strategy_coef, min_sep=sep, max_participations=participations
       )
       pqe = toeplitz.per_query_error(strategy_coef=strategy_coef, n=n)
+      loss = reduction_fn(pqe) * sensitivity_squared
+
+    case 'banded-inverse-sqrt':
+      # https://arxiv.org/pdf/2505.12128
+      weight_decay = 1.0
+      momentum = 0.0
+      workload_coef = toeplitz.multiply(
+          weight_decay**jnp.arange(n),
+          momentum**jnp.arange(n),
+          n=n,
+          skip_checks=True,
+      )
+      noising_coef = toeplitz.banded_inverse_square_root_noising_coefs(
+          sep, weight_decay=weight_decay, momentum=momentum
+      )
+      sensitivity_squared = toeplitz.compute_banded_inverse_sensitivity(
+          n=n,
+          noising_coef=noising_coef,
+          min_sep=sep,
+          max_participations=participations,
+      ) ** 2
+      pqe = toeplitz.per_query_error(
+          noising_coef=noising_coef, n=n, workload_coef=workload_coef
+      )
       loss = reduction_fn(pqe) * sensitivity_squared
 
     case 'banded':

--- a/examples/dpmf_strategy_optimization.py
+++ b/examples/dpmf_strategy_optimization.py
@@ -111,8 +111,8 @@ def optimize_strategy(
       weight_decay = 1.0
       momentum = 0.0
       workload_coef = toeplitz.multiply(
-          weight_decay**jnp.arange(n),
-          momentum**jnp.arange(n),
+          weight_decay ** jnp.arange(n),
+          momentum ** jnp.arange(n),
           n=n,
           skip_checks=True,
       )
@@ -122,14 +122,15 @@ def optimize_strategy(
           num_bands=sep,
           weight_decay=weight_decay,
           momentum=momentum,
-          max_optimizer_steps=10,
+          max_optimizer_steps=1000,
+          reduction_fn=reduction_fn,
       )
-      sensitivity_squared = toeplitz.compute_banded_inverse_sensitivity(
+      sensitivity_squared = toeplitz.compute_banded_inverse_sensitivity_squared(
           n=n,
           noising_coef=noising_coef,
           min_sep=sep,
           max_participations=participations,
-      ) ** 2
+      ) 
       pqe = toeplitz.per_query_error(
           noising_coef=noising_coef, n=n, workload_coef=workload_coef
       )
@@ -163,6 +164,7 @@ def optimize_strategy(
       # https://arxiv.org/abs/2202.11205
       # https://arxiv.org/abs/2405.13763
       strategy_coef = toeplitz.optimal_max_error_strategy_coefs(sep)
+      strategy_coef = jnp.concatenate([strategy_coef, jnp.zeros(n - sep)])
       sensitivity_squared = toeplitz.minsep_sensitivity_squared(
           strategy_coef, min_sep=sep, max_participations=participations
       )
@@ -174,20 +176,20 @@ def optimize_strategy(
       weight_decay = 1.0
       momentum = 0.0
       workload_coef = toeplitz.multiply(
-          weight_decay**jnp.arange(n),
-          momentum**jnp.arange(n),
+          weight_decay ** jnp.arange(n),
+          momentum ** jnp.arange(n),
           n=n,
           skip_checks=True,
       )
       noising_coef = toeplitz.banded_inverse_square_root_noising_coefs(
           sep, weight_decay=weight_decay, momentum=momentum
       )
-      sensitivity_squared = toeplitz.compute_banded_inverse_sensitivity(
+      sensitivity_squared = toeplitz.compute_banded_inverse_sensitivity_squared(
           n=n,
           noising_coef=noising_coef,
           min_sep=sep,
           max_participations=participations,
-      ) ** 2
+      )
       pqe = toeplitz.per_query_error(
           noising_coef=noising_coef, n=n, workload_coef=workload_coef
       )

--- a/jax_privacy/matrix_factorization/toeplitz.py
+++ b/jax_privacy/matrix_factorization/toeplitz.py
@@ -736,6 +736,7 @@ def optimize_coefs_for_amplifications(
   return coef, stddev
 
 
+@functools.partial(jax.jit, static_argnums=[0])
 def banded_inverse_square_root_noising_coefs(
     num_bands: int,
     workload_coef: jax.Array | None = None,
@@ -837,6 +838,7 @@ def optimize_banded_inverse_toeplitz(
     n: int,
     min_sep: int,
     num_bands: int,
+    *,
     noising_coef: jax.Array | None = None,
     strategy_coef: jax.Array | None = None,
     workload_coef: jax.Array | None = None,

--- a/jax_privacy/matrix_factorization/toeplitz.py
+++ b/jax_privacy/matrix_factorization/toeplitz.py
@@ -775,7 +775,8 @@ def compute_banded_inverse_sensitivity_squared(
     max_participations: int | None = None,
     use_matrix_upper_bound: bool = False,
 ) -> jax.Array:
-  """Returns the squared sensitivity of a banded inverse Toeplitz noising matrix.
+  """Returns the squared sensitivity of a banded inverse Toeplitz noising
+  matrix.
 
   This function takes Toeplitz coefficients of a lower-triangular noising
   matrix $C^{-1}$, computes the implied strategy coefficients for $C$, and then
@@ -863,7 +864,8 @@ def optimize_banded_inverse_toeplitz(
       Defaults to jnp.mean.
 
   Returns:
-    The optimized Toeplitz coefficients of the lower-triangular noising matrix $C^{-1}$.
+    The optimized Toeplitz coefficients of the lower-triangular noising
+    matrix $C^{-1}$.
   """
   workload_coef = multiply(
       weight_decay ** jnp.arange(n),

--- a/jax_privacy/matrix_factorization/toeplitz.py
+++ b/jax_privacy/matrix_factorization/toeplitz.py
@@ -741,7 +741,7 @@ def banded_inverse_square_root_noising_coefs(
     weight_decay: float = 1.0,
     momentum: float = 0.0,
 ) -> jax.Array:
-  """Returns Toeplitz noising coefficients for the BISR factorization.
+  r"""Returns Toeplitz noising coefficients for the BISR factorization.
 
   This computes the first `num_bands` coefficients of the lower-triangular
   Toeplitz noising matrix $C^{-1}$ for the Banded Inverse Square Root (BISR)
@@ -808,17 +808,22 @@ def compute_banded_inverse_sensitivity_squared(
   if not use_matrix_upper_bound:
     coef_for_upper_bound = jax.lax.cummax(jnp.abs(strategy_coef)[::-1])[::-1]
     return minsep_sensitivity_squared(
-                coef_for_upper_bound,
-                min_sep=min_sep,
-                max_participations=max_participations,
-                n=n,
-                skip_checks=True,
+        coef_for_upper_bound,
+        min_sep=min_sep,
+        max_participations=max_participations,
+        n=n,
+        skip_checks=True,
     )
 
   strategy_matrix = materialize_lower_triangular(jnp.abs(strategy_coef), n)
-  return sensitivity.get_min_sep_sensitivity_upper_bound(
-      strategy_matrix, min_sep=min_sep, max_participations=max_participations
-  ) ** 2
+  return (
+      sensitivity.get_min_sep_sensitivity_upper_bound(
+          strategy_matrix,
+          min_sep=min_sep,
+          max_participations=max_participations,
+      )
+      ** 2
+  )
 
 
 def optimize_banded_inverse_toeplitz(

--- a/jax_privacy/matrix_factorization/toeplitz.py
+++ b/jax_privacy/matrix_factorization/toeplitz.py
@@ -738,34 +738,41 @@ def optimize_coefs_for_amplifications(
 
 def banded_inverse_square_root_noising_coefs(
     num_bands: int,
-    weight_decay: float = 1.0,
-    momentum: float = 0.0,
+    workload_coef: jax.Array | None = None,
 ) -> jax.Array:
-  r"""Returns Toeplitz noising coefficients for the BISR factorization.
+  """Returns Toeplitz noising coefficients for the BISR factorization.
 
   This computes the first `num_bands` coefficients of the lower-triangular
   Toeplitz noising matrix $C^{-1}$ for the Banded Inverse Square Root (BISR)
-  factorization introduced in https://arxiv.org/pdf/2505.12128.
-
-  Following Lemma 1, if
-  $\sqrt{1 - x} = \sum_{k \geq 0} r_k x^k$, then the returned coefficients are
-  the convolution of `r_k * weight_decay**k` and `r_k * momentum**k`.
+  factorization introduced in https://arxiv.org/pdf/2505.12128. If
+  `workload_coef` is not provided, this uses the default prefix-sum workload
+  with all-ones Toeplitz coefficients. If `workload_coef` is provided, then it
+  is treated as the Toeplitz coefficients of the workload; this can encode
+  workload families such as those induced by SGD with momentum and weight
+  decay. In that case, this function computes Toeplitz coefficients of the
+  square root of the workload and then returns the first `num_bands`
+  coefficients of its inverse.
 
   Args:
     num_bands: The number of coefficients to return.
-    weight_decay: The weight decay factor.
-    momentum: The momentum factor.
+    workload_coef: Optional Toeplitz coefficients of the workload.
 
   Returns:
     The coefficients of the lower-triangular Toeplitz noising matrix $C^{-1}$.
   """
-  k = jnp.arange(num_bands)
-  sqrt_coefs = jnp.cumprod(((k - 3 / 2) / k).at[0].set(1.0))
-  weight_decay_coefs = sqrt_coefs * weight_decay**k
-  momentum_coefs = sqrt_coefs * momentum**k
-  return multiply(
-      weight_decay_coefs, momentum_coefs, n=num_bands, skip_checks=True
-  )
+  if workload_coef is None:
+    k = jnp.arange(num_bands)
+    return jnp.cumprod(((k - 3 / 2) / k).at[0].set(1.0))
+
+  workload_coef = pad_coefs_to_n(workload_coef, num_bands)
+  sqrt_coefs = jnp.zeros(num_bands, dtype=workload_coef.dtype)
+  sqrt_coefs = sqrt_coefs.at[0].set(jnp.sqrt(workload_coef[0]))
+  for j in range(1, num_bands):
+    inner = jnp.dot(sqrt_coefs[1:j], sqrt_coefs[1:j][::-1])
+    sqrt_coefs = sqrt_coefs.at[j].set(
+        (workload_coef[j] - inner) / (2 * sqrt_coefs[0])
+    )
+  return inverse_coef(sqrt_coefs, num_bands)[:num_bands]
 
 
 def compute_banded_inverse_sensitivity_squared(
@@ -816,31 +823,28 @@ def compute_banded_inverse_sensitivity_squared(
     )
 
   strategy_matrix = materialize_lower_triangular(jnp.abs(strategy_coef), n)
-  return (
-      sensitivity.get_min_sep_sensitivity_upper_bound(
+  return sensitivity.get_min_sep_sensitivity_upper_bound(
           strategy_matrix,
           min_sep=min_sep,
           max_participations=max_participations,
-      )
-      ** 2
-  )
-
+      ) ** 2
 
 def optimize_banded_inverse_toeplitz(
     n: int,
     min_sep: int,
     num_bands: int,
     noising_coef: jax.Array | None = None,
+    strategy_coef: jax.Array | None = None,
+    workload_coef: jax.Array | None = None,
     max_participations: int | None = None,
-    weight_decay: float = 1.0,
-    momentum: float = 0.0,
     max_optimizer_steps: int = 1000,
     reduction_fn: Callable[[jax.Array], jax.Array] = jnp.mean,
 ) -> jax.Array:
   """Optimize over banded inverse Toeplitz noising matrices for BandInvMF.
 
   This function optimizes directly over the Toeplitz coefficients of the
-  lower-triangular noising matrix $C^{-1}$ for the BandInvMF workload from
+  lower-triangular noising matrix $C^{-1}$ for a Toeplitz workload, following
+  the BandInvMF construction introduced in
   https://arxiv.org/pdf/2505.12128. The objective is the reduced per-query
   squared error on the induced workload times the squared `min_sep`
   sensitivity of the implied strategy matrix $C$.
@@ -851,11 +855,15 @@ def optimize_banded_inverse_toeplitz(
     num_bands: The number of Toeplitz coefficients of the noising matrix to
       optimize, including the diagonal.
     noising_coef: Optional initialization for the noising coefficients. If not
-      provided, initializes from `banded_inverse_square_root_noising_coefs`.
+      provided, initializes from `strategy_coef` if given, otherwise from
+      `banded_inverse_square_root_noising_coefs(workload_coef=...)`.
       If longer than `num_bands`, the extra coefficients are ignored.
+    strategy_coef: Optional initialization for the strategy coefficients. If
+      provided, the corresponding noising coefficients are computed via
+      `inverse_coef`.
+    workload_coef: Optional Toeplitz coefficients of the workload. If not
+      provided, the default prefix-sum workload of all ones is used.
     max_participations: Optional cap on the number of participations.
-    weight_decay: The weight decay factor defining the workload.
-    momentum: The momentum factor defining the workload.
     max_optimizer_steps: The maximum number of L-BFGS iterations.
     reduction_fn: A function that converts per query squared errors to a scalar.
       Use jnp.mean to optimize mean-squared-error, jnp.max to optimize max
@@ -866,12 +874,10 @@ def optimize_banded_inverse_toeplitz(
     The optimized Toeplitz coefficients of the lower-triangular noising
     matrix $C^{-1}$.
   """
-  workload_coef = multiply(
-      weight_decay ** jnp.arange(n),
-      momentum ** jnp.arange(n),
-      n=n,
-      skip_checks=True,
-  )
+  if workload_coef is None:
+    workload_coef = jnp.ones(n)
+  else:
+    workload_coef = pad_coefs_to_n(workload_coef, n)
 
   def loss_fn(coef: jax.Array) -> jax.Array:
     error = reduction_fn(
@@ -893,9 +899,12 @@ def optimize_banded_inverse_toeplitz(
     return error * sens_squared
 
   if noising_coef is None:
-    noising_coef = banded_inverse_square_root_noising_coefs(
-        num_bands, weight_decay=weight_decay, momentum=momentum
-    )
+    if strategy_coef is not None:
+      noising_coef = inverse_coef(strategy_coef, num_bands)
+    else:
+      noising_coef = banded_inverse_square_root_noising_coefs(
+          num_bands, workload_coef=workload_coef
+      )
   noising_coef = pad_coefs_to_n(noising_coef, num_bands)
 
   params = optimization.optimize(

--- a/jax_privacy/matrix_factorization/toeplitz.py
+++ b/jax_privacy/matrix_factorization/toeplitz.py
@@ -767,14 +767,15 @@ def banded_inverse_square_root_noising_coefs(
       weight_decay_coefs, momentum_coefs, n=num_bands, skip_checks=True
   )
 
-def compute_banded_inverse_sensitivity(
+
+def compute_banded_inverse_sensitivity_squared(
     n: int,
     noising_coef: jax.Array,
     min_sep: int,
     max_participations: int | None = None,
     use_matrix_upper_bound: bool = False,
-) -> float:
-  """Returns the sensitivity of a banded inverse Toeplitz noising matrix.
+) -> jax.Array:
+  """Returns the squared sensitivity of a banded inverse Toeplitz noising matrix.
 
   This function takes Toeplitz coefficients of a lower-triangular noising
   matrix $C^{-1}$, computes the implied strategy coefficients for $C$, and then
@@ -800,33 +801,24 @@ def compute_banded_inverse_sensitivity(
       bound.
 
   Returns:
-    The b-min-separated sensitivity of the implied strategy matrix $C$.
+    The squared b-min-separated sensitivity of the implied strategy matrix $C$.
   """
-  noising_coef = pad_coefs_to_n(noising_coef, n)
   strategy_coef = inverse_coef(noising_coef, n)
-  abs_strategy_coef = jnp.abs(strategy_coef)
-  is_nonincreasing = jnp.all(abs_strategy_coef[1:] <= abs_strategy_coef[:-1])
 
   if not use_matrix_upper_bound:
-    coef_for_upper_bound = abs_strategy_coef
-    if not is_nonincreasing:
-      coef_for_upper_bound = jax.lax.cummax(abs_strategy_coef[::-1])[::-1]
-    return float(
-        jnp.sqrt(
-            minsep_sensitivity_squared(
+    coef_for_upper_bound = jax.lax.cummax(jnp.abs(strategy_coef)[::-1])[::-1]
+    return minsep_sensitivity_squared(
                 coef_for_upper_bound,
                 min_sep=min_sep,
                 max_participations=max_participations,
                 n=n,
                 skip_checks=True,
-            )
-        )
     )
 
-  strategy_matrix = materialize_lower_triangular(abs_strategy_coef, n)
+  strategy_matrix = materialize_lower_triangular(jnp.abs(strategy_coef), n)
   return sensitivity.get_min_sep_sensitivity_upper_bound(
       strategy_matrix, min_sep=min_sep, max_participations=max_participations
-  )
+  ) ** 2
 
 
 def optimize_banded_inverse_toeplitz(
@@ -834,17 +826,19 @@ def optimize_banded_inverse_toeplitz(
     min_sep: int,
     num_bands: int,
     noising_coef: jax.Array | None = None,
+    max_participations: int | None = None,
     weight_decay: float = 1.0,
     momentum: float = 0.0,
-    max_optimizer_steps: int = 10,
+    max_optimizer_steps: int = 1000,
+    reduction_fn: Callable[[jax.Array], jax.Array] = jnp.mean,
 ) -> jax.Array:
   """Optimize over banded inverse Toeplitz noising matrices for BandInvMF.
 
   This function optimizes directly over the Toeplitz coefficients of the
   lower-triangular noising matrix $C^{-1}$ for the BandInvMF workload from
-  https://arxiv.org/pdf/2505.12128. The objective is mean per-query squared
-  error on the induced workload times the squared `min_sep` sensitivity of the
-  implied strategy matrix $C$.
+  https://arxiv.org/pdf/2505.12128. The objective is the reduced per-query
+  squared error on the induced workload times the squared `min_sep`
+  sensitivity of the implied strategy matrix $C$.
 
   Args:
     n: The number of iterations that defines the workload.
@@ -854,23 +848,27 @@ def optimize_banded_inverse_toeplitz(
     noising_coef: Optional initialization for the noising coefficients. If not
       provided, initializes from `banded_inverse_square_root_noising_coefs`.
       If longer than `num_bands`, the extra coefficients are ignored.
+    max_participations: Optional cap on the number of participations.
     weight_decay: The weight decay factor defining the workload.
     momentum: The momentum factor defining the workload.
     max_optimizer_steps: The maximum number of L-BFGS iterations.
+    reduction_fn: A function that converts per query squared errors to a scalar.
+      Use jnp.mean to optimize mean-squared-error, jnp.max to optimize max
+      squared error, or lambda v: v[-1] to optimize last iterate squared error.
+      Defaults to jnp.mean.
 
   Returns:
     The optimized Toeplitz coefficients of the lower-triangular noising matrix $C^{-1}$.
   """
   workload_coef = multiply(
-      weight_decay**jnp.arange(n),
-      momentum**jnp.arange(n),
+      weight_decay ** jnp.arange(n),
+      momentum ** jnp.arange(n),
       n=n,
       skip_checks=True,
   )
 
   def loss_fn(coef: jax.Array) -> jax.Array:
-    strategy_coef = solve_banded(coef, jnp.zeros(n).at[0].set(1))
-    error = jnp.mean(
+    error = reduction_fn(
         per_query_error(
             noising_coef=coef,
             n=n,
@@ -878,12 +876,12 @@ def optimize_banded_inverse_toeplitz(
             skip_checks=True,
         )
     )
-    sens_squared = minsep_sensitivity_squared(
-        strategy_coef,
-        min_sep=min_sep,
-        max_participations=None,
+    sens_squared = compute_banded_inverse_sensitivity_squared(
         n=n,
-        skip_checks=True,
+        noising_coef=coef,
+        min_sep=min_sep,
+        max_participations=max_participations,
+        use_matrix_upper_bound=False,
     )
 
     return error * sens_squared
@@ -895,6 +893,6 @@ def optimize_banded_inverse_toeplitz(
   noising_coef = pad_coefs_to_n(noising_coef, num_bands)
 
   params = optimization.optimize(
-        loss_fn, noising_coef, max_optimizer_steps=max_optimizer_steps
+      loss_fn, noising_coef, max_optimizer_steps=max_optimizer_steps
   )
   return params / params[0]

--- a/jax_privacy/matrix_factorization/toeplitz.py
+++ b/jax_privacy/matrix_factorization/toeplitz.py
@@ -775,8 +775,7 @@ def compute_banded_inverse_sensitivity_squared(
     max_participations: int | None = None,
     use_matrix_upper_bound: bool = False,
 ) -> jax.Array:
-  """Returns the squared sensitivity of a banded inverse Toeplitz noising
-  matrix.
+  """Returns squared sensitivity for a banded inverse Toeplitz noising matrix.
 
   This function takes Toeplitz coefficients of a lower-triangular noising
   matrix $C^{-1}$, computes the implied strategy coefficients for $C$, and then

--- a/jax_privacy/matrix_factorization/toeplitz.py
+++ b/jax_privacy/matrix_factorization/toeplitz.py
@@ -823,11 +823,15 @@ def compute_banded_inverse_sensitivity_squared(
     )
 
   strategy_matrix = materialize_lower_triangular(jnp.abs(strategy_coef), n)
-  return sensitivity.get_min_sep_sensitivity_upper_bound(
+  return (
+      sensitivity.get_min_sep_sensitivity_upper_bound(
           strategy_matrix,
           min_sep=min_sep,
           max_participations=max_participations,
-      ) ** 2
+      )
+      ** 2
+  )
+
 
 def optimize_banded_inverse_toeplitz(
     n: int,

--- a/jax_privacy/matrix_factorization/toeplitz.py
+++ b/jax_privacy/matrix_factorization/toeplitz.py
@@ -734,3 +734,167 @@ def optimize_coefs_for_amplifications(
   coef = helper.optimize_bands(max_optimizer_steps=max_optimizer_steps)['coef']
   stddev = helper.required_stddev(coef)
   return coef, stddev
+
+
+def banded_inverse_square_root_noising_coefs(
+    num_bands: int,
+    weight_decay: float = 1.0,
+    momentum: float = 0.0,
+) -> jax.Array:
+  """Returns Toeplitz noising coefficients for the BISR factorization.
+
+  This computes the first `num_bands` coefficients of the lower-triangular
+  Toeplitz noising matrix $C^{-1}$ for the Banded Inverse Square Root (BISR)
+  factorization introduced in https://arxiv.org/pdf/2505.12128.
+
+  Following Lemma 1, if
+  $\sqrt{1 - x} = \sum_{k \geq 0} r_k x^k$, then the returned coefficients are
+  the convolution of `r_k * weight_decay**k` and `r_k * momentum**k`.
+
+  Args:
+    num_bands: The number of coefficients to return.
+    weight_decay: The weight decay factor.
+    momentum: The momentum factor.
+
+  Returns:
+    The coefficients of the lower-triangular Toeplitz noising matrix $C^{-1}$.
+  """
+  k = jnp.arange(num_bands)
+  sqrt_coefs = jnp.cumprod(((k - 3 / 2) / k).at[0].set(1.0))
+  weight_decay_coefs = sqrt_coefs * weight_decay**k
+  momentum_coefs = sqrt_coefs * momentum**k
+  return multiply(
+      weight_decay_coefs, momentum_coefs, n=num_bands, skip_checks=True
+  )
+
+def compute_banded_inverse_sensitivity(
+    n: int,
+    noising_coef: jax.Array,
+    min_sep: int,
+    max_participations: int | None = None,
+    use_matrix_upper_bound: bool = False,
+) -> float:
+  """Returns the sensitivity of a banded inverse Toeplitz noising matrix.
+
+  This function takes Toeplitz coefficients of a lower-triangular noising
+  matrix $C^{-1}$, computes the implied strategy coefficients for $C$, and then
+  estimates the min-separation sensitivity of $C$.
+
+  If the absolute strategy coefficients are non-increasing, this uses the
+  closed-form Toeplitz sensitivity computation in
+  `minsep_sensitivity_squared`. Otherwise, if `use_matrix_upper_bound` is
+  False, it projects the absolute strategy coefficients onto the smallest
+  non-increasing majorant and uses that to obtain an upper bound. If
+  `use_matrix_upper_bound` is True, it materializes the Toeplitz matrix with
+  absolute strategy coefficients and uses the generic sensitivity upper bound
+  from `sensitivity.py`. This path is computationally heavier.
+
+  Args:
+    n: The size of the implied Toeplitz matrix.
+    noising_coef: The Toeplitz coefficients of the noising matrix $C^{-1}$.
+    min_sep: The minimum separation between participations.
+    max_participations: Optional cap on the number of participations.
+    use_matrix_upper_bound: Whether to use the generic matrix-based upper bound
+      when the absolute strategy coefficients are not non-increasing. This is
+      computationally heavier than the default projected-coefficient upper
+      bound.
+
+  Returns:
+    The b-min-separated sensitivity of the implied strategy matrix $C$.
+  """
+  noising_coef = pad_coefs_to_n(noising_coef, n)
+  strategy_coef = inverse_coef(noising_coef, n)
+  abs_strategy_coef = jnp.abs(strategy_coef)
+  is_nonincreasing = jnp.all(abs_strategy_coef[1:] <= abs_strategy_coef[:-1])
+
+  if not use_matrix_upper_bound:
+    coef_for_upper_bound = abs_strategy_coef
+    if not is_nonincreasing:
+      coef_for_upper_bound = jax.lax.cummax(abs_strategy_coef[::-1])[::-1]
+    return float(
+        jnp.sqrt(
+            minsep_sensitivity_squared(
+                coef_for_upper_bound,
+                min_sep=min_sep,
+                max_participations=max_participations,
+                n=n,
+                skip_checks=True,
+            )
+        )
+    )
+
+  strategy_matrix = materialize_lower_triangular(abs_strategy_coef, n)
+  return sensitivity.get_min_sep_sensitivity_upper_bound(
+      strategy_matrix, min_sep=min_sep, max_participations=max_participations
+  )
+
+
+def optimize_banded_inverse_toeplitz(
+    n: int,
+    min_sep: int,
+    num_bands: int,
+    noising_coef: jax.Array | None = None,
+    weight_decay: float = 1.0,
+    momentum: float = 0.0,
+    max_optimizer_steps: int = 10,
+) -> jax.Array:
+  """Optimize over banded inverse Toeplitz noising matrices for BandInvMF.
+
+  This function optimizes directly over the Toeplitz coefficients of the
+  lower-triangular noising matrix $C^{-1}$ for the BandInvMF workload from
+  https://arxiv.org/pdf/2505.12128. The objective is mean per-query squared
+  error on the induced workload times the squared `min_sep` sensitivity of the
+  implied strategy matrix $C$.
+
+  Args:
+    n: The number of iterations that defines the workload.
+    min_sep: The minimum separation between contributions from the same user.
+    num_bands: The number of Toeplitz coefficients of the noising matrix to
+      optimize, including the diagonal.
+    noising_coef: Optional initialization for the noising coefficients. If not
+      provided, initializes from `banded_inverse_square_root_noising_coefs`.
+      If longer than `num_bands`, the extra coefficients are ignored.
+    weight_decay: The weight decay factor defining the workload.
+    momentum: The momentum factor defining the workload.
+    max_optimizer_steps: The maximum number of L-BFGS iterations.
+
+  Returns:
+    The optimized Toeplitz coefficients of the lower-triangular noising matrix $C^{-1}$.
+  """
+  workload_coef = multiply(
+      weight_decay**jnp.arange(n),
+      momentum**jnp.arange(n),
+      n=n,
+      skip_checks=True,
+  )
+
+  def loss_fn(coef: jax.Array) -> jax.Array:
+    strategy_coef = solve_banded(coef, jnp.zeros(n).at[0].set(1))
+    error = jnp.mean(
+        per_query_error(
+            noising_coef=coef,
+            n=n,
+            workload_coef=workload_coef,
+            skip_checks=True,
+        )
+    )
+    sens_squared = minsep_sensitivity_squared(
+        strategy_coef,
+        min_sep=min_sep,
+        max_participations=None,
+        n=n,
+        skip_checks=True,
+    )
+
+    return error * sens_squared
+
+  if noising_coef is None:
+    noising_coef = banded_inverse_square_root_noising_coefs(
+        num_bands, weight_decay=weight_decay, momentum=momentum
+    )
+  noising_coef = pad_coefs_to_n(noising_coef, num_bands)
+
+  params = optimization.optimize(
+        loss_fn, noising_coef, max_optimizer_steps=max_optimizer_steps
+  )
+  return params / params[0]

--- a/jax_privacy/matrix_factorization/toeplitz.py
+++ b/jax_privacy/matrix_factorization/toeplitz.py
@@ -884,8 +884,6 @@ def optimize_banded_inverse_toeplitz(
       Use jnp.mean to optimize mean-squared-error, jnp.max to optimize max
       squared error, or lambda v: v[-1] to optimize last iterate squared error.
       Defaults to jnp.mean.
-    skip_checks: If True, don't perform input verification. It may be
-      necessary to set skip_checks=True when this function is jitted.
 
   Returns:
     The optimized Toeplitz coefficients of the lower-triangular noising

--- a/jax_privacy/matrix_factorization/toeplitz.py
+++ b/jax_privacy/matrix_factorization/toeplitz.py
@@ -423,6 +423,7 @@ def per_query_error(
   else:
     assert noising_coef is not None
     noising_coef, n = _reconcile(noising_coef, n)
+    noising_coef = jnp.pad(noising_coef, (0, n - noising_coef.shape[0]))
     if workload_coef is None:
       # This is more efficient than explicitly multiplying by the prefix matrix.
       B_coef = jnp.cumsum(noising_coef)
@@ -853,7 +854,6 @@ def optimize_banded_inverse_toeplitz(
     max_participations: int | None = None,
     max_optimizer_steps: int = 1000,
     reduction_fn: Callable[[jax.Array], jax.Array] = jnp.mean,
-    skip_checks: bool = False,
 ) -> jax.Array:
   """Optimize over banded inverse Toeplitz noising matrices for BandInvMF.
 
@@ -894,7 +894,7 @@ def optimize_banded_inverse_toeplitz(
   if workload_coef is None:
     workload_coef = jnp.ones(n)
   else:
-    if not skip_checks and workload_coef.shape[0] != n:
+    if workload_coef.shape[0] != n:
       raise ValueError(f'{workload_coef.shape[0]=} != {n=}')
 
   def loss_fn(coef: jax.Array) -> jax.Array:
@@ -903,7 +903,7 @@ def optimize_banded_inverse_toeplitz(
             noising_coef=coef,
             n=n,
             workload_coef=workload_coef,
-            skip_checks=skip_checks,
+            skip_checks=False,
         )
     )
     sens_squared = compute_banded_inverse_sensitivity_squared(

--- a/jax_privacy/matrix_factorization/toeplitz.py
+++ b/jax_privacy/matrix_factorization/toeplitz.py
@@ -762,8 +762,7 @@ def banded_inverse_square_root_noising_coefs(
     The coefficients of the lower-triangular Toeplitz noising matrix $C^{-1}$.
   """
   if workload_coef is None:
-    k = jnp.arange(num_bands)
-    return jnp.cumprod(((k - 3 / 2) / k).at[0].set(1.0))
+    return optimal_max_error_noising_coefs(num_bands)
 
   workload_coef = pad_coefs_to_n(workload_coef, num_bands)
   sqrt_coefs = jnp.zeros(num_bands, dtype=workload_coef.dtype)
@@ -789,24 +788,33 @@ def compute_banded_inverse_sensitivity_squared(
   matrix $C^{-1}$, computes the implied strategy coefficients for $C$, and then
   estimates the min-separation sensitivity of $C$.
 
-  If the absolute strategy coefficients are non-increasing, this uses the
-  closed-form Toeplitz sensitivity computation in
-  `minsep_sensitivity_squared`. Otherwise, if `use_matrix_upper_bound` is
-  False, it projects the absolute strategy coefficients onto the smallest
-  non-increasing majorant and uses that to obtain an upper bound. If
-  `use_matrix_upper_bound` is True, it materializes the Toeplitz matrix with
-  absolute strategy coefficients and uses the generic sensitivity upper bound
-  from `sensitivity.py`. This path is computationally heavier.
+  Tightness depends on the sign and monotonicity of the implied strategy
+  coefficients. If the strategy coefficients are positive and
+  non-increasing, this uses the closed-form Toeplitz sensitivity computation in
+  `minsep_sensitivity_squared`, which is exact.
+
+  Otherwise, the behavior depends on `use_matrix_upper_bound`:
+
+  - If False, the absolute strategy coefficients are projected onto the
+    smallest non-increasing majorant, and the resulting sequence is used to
+    compute an upper bound. This bound is exact when the strategy coefficients
+    are positive and decreasing, but may be looser when they are not
+    non-increasing.
+
+  - If True, the Toeplitz matrix formed from the absolute strategy
+    coefficients is materialized, and the generic sensitivity upper bound from
+    `sensitivity.py` is used instead. This is more computationally expensive,
+    but gives a tighter bound when the sequence is not non-increasing, and is
+    exact when the strategy coefficients are positive.
 
   Args:
-    n: The size of the implied Toeplitz matrix.
-    noising_coef: The Toeplitz coefficients of the noising matrix $C^{-1}$.
-    min_sep: The minimum separation between participations.
+    n: Size of the implied Toeplitz matrix.
+    noising_coef: Toeplitz coefficients of the noising matrix $C^{-1}$.
+    min_sep: Minimum separation between participations.
     max_participations: Optional cap on the number of participations.
     use_matrix_upper_bound: Whether to use the generic matrix-based upper bound
-      when the absolute strategy coefficients are not non-increasing. This is
-      computationally heavier than the default projected-coefficient upper
-      bound.
+      instead of the projected-coefficient upper bound when the absolute
+      strategy coefficients are not non-increasing.
 
   Returns:
     The squared b-min-separated sensitivity of the implied strategy matrix $C$.
@@ -845,6 +853,7 @@ def optimize_banded_inverse_toeplitz(
     max_participations: int | None = None,
     max_optimizer_steps: int = 1000,
     reduction_fn: Callable[[jax.Array], jax.Array] = jnp.mean,
+    skip_checks: bool = False,
 ) -> jax.Array:
   """Optimize over banded inverse Toeplitz noising matrices for BandInvMF.
 
@@ -875,6 +884,8 @@ def optimize_banded_inverse_toeplitz(
       Use jnp.mean to optimize mean-squared-error, jnp.max to optimize max
       squared error, or lambda v: v[-1] to optimize last iterate squared error.
       Defaults to jnp.mean.
+    skip_checks: If True, don't perform input verification. It may be
+      necessary to set skip_checks=True when this function is jitted.
 
   Returns:
     The optimized Toeplitz coefficients of the lower-triangular noising
@@ -883,7 +894,8 @@ def optimize_banded_inverse_toeplitz(
   if workload_coef is None:
     workload_coef = jnp.ones(n)
   else:
-    workload_coef = pad_coefs_to_n(workload_coef, n)
+    if not skip_checks and workload_coef.shape[0] != n:
+      raise ValueError(f'{workload_coef.shape[0]=} != {n=}')
 
   def loss_fn(coef: jax.Array) -> jax.Array:
     error = reduction_fn(
@@ -891,7 +903,7 @@ def optimize_banded_inverse_toeplitz(
             noising_coef=coef,
             n=n,
             workload_coef=workload_coef,
-            skip_checks=True,
+            skip_checks=skip_checks,
         )
     )
     sens_squared = compute_banded_inverse_sensitivity_squared(

--- a/tests/matrix_factorization/toeplitz_test.py
+++ b/tests/matrix_factorization/toeplitz_test.py
@@ -17,8 +17,6 @@
 # may occur. If `jax` is installed via a pip package, it should already be
 # optimized.
 
-"""Tests for toeplitz.py."""
-
 from absl.testing import absltest
 from absl.testing import parameterized
 import dp_accounting

--- a/tests/matrix_factorization/toeplitz_test.py
+++ b/tests/matrix_factorization/toeplitz_test.py
@@ -17,6 +17,7 @@
 # may occur. If `jax` is installed via a pip package, it should already be
 # optimized.
 
+"""Tests for toeplitz.py."""
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -164,12 +165,14 @@ class ToeplitzTest(parameterized.TestCase):
     noising_coef = toeplitz.banded_inverse_square_root_noising_coefs(num_bands)
     strategy_coef = toeplitz.inverse_coef(noising_coef, n=n)
 
-    projected_sensitivity_squared = toeplitz.compute_banded_inverse_sensitivity_squared(
+    projected_sensitivity_squared = (
+        toeplitz.compute_banded_inverse_sensitivity_squared(
             n=n,
             noising_coef=noising_coef,
             min_sep=min_sep,
             max_participations=max_participations,
             use_matrix_upper_bound=False,
+        )
     )
     matrix_sensitivity_squared = (
         toeplitz.compute_banded_inverse_sensitivity_squared(
@@ -572,11 +575,13 @@ class ToeplitzOptimizationTest(parameterized.TestCase):
             workload_coef=workload_coef,
         )
     )
-    bisr_sensitivity_squared = toeplitz.compute_banded_inverse_sensitivity_squared(
-        n=n,
-        noising_coef=bisr_coef,
-        min_sep=min_sep,
-        max_participations=max_participations,
+    bisr_sensitivity_squared = (
+        toeplitz.compute_banded_inverse_sensitivity_squared(
+            n=n,
+            noising_coef=bisr_coef,
+            min_sep=min_sep,
+            max_participations=max_participations,
+        )
     )
     bisr_loss = bisr_error * bisr_sensitivity_squared
 

--- a/tests/matrix_factorization/toeplitz_test.py
+++ b/tests/matrix_factorization/toeplitz_test.py
@@ -148,9 +148,17 @@ class ToeplitzTest(parameterized.TestCase):
     )
 
   def test_banded_inverse_square_root_noising_coefs(self):
+    expected = jnp.array([1, -1 / 2, -1 / 8, -1 / 16, -5 / 128])
     np.testing.assert_allclose(
         toeplitz.banded_inverse_square_root_noising_coefs(5),
-        jnp.array([1, -1 / 2, -1 / 8, -1 / 16, -5 / 128]),
+        expected,
+        atol=1e-6,
+    )
+    np.testing.assert_allclose(
+        toeplitz.banded_inverse_square_root_noising_coefs(
+            5, workload_coef=jnp.ones(5)
+        ),
+        expected,
         atol=1e-6,
     )
 
@@ -524,29 +532,18 @@ class ToeplitzOptimizationTest(parameterized.TestCase):
     n = 128
     min_sep = n // max_participations
     num_bands = 8
-    weight_decay = 1.0
-    momentum = 0.0
-
-    workload_coef = toeplitz.multiply(
-        weight_decay ** jnp.arange(n),
-        momentum ** jnp.arange(n),
-        n=n,
-        skip_checks=True,
-    )
+    workload_coef = jnp.ones(n)
 
     optimized_coef = toeplitz.optimize_banded_inverse_toeplitz(
         n=n,
         min_sep=min_sep,
         num_bands=num_bands,
         max_participations=max_participations,
-        weight_decay=weight_decay,
-        momentum=momentum,
-        max_optimizer_steps=100,
+        workload_coef=workload_coef,
+        max_optimizer_steps=30,
         reduction_fn=jnp.mean,
     )
-    bisr_coef = toeplitz.banded_inverse_square_root_noising_coefs(
-        num_bands, weight_decay=weight_decay, momentum=momentum
-    )
+    bisr_coef = toeplitz.banded_inverse_square_root_noising_coefs(num_bands)
 
     self.assertTrue(jnp.all(jnp.isfinite(optimized_coef)))
     np.testing.assert_allclose(optimized_coef[0], 1.0, atol=1e-6)

--- a/tests/matrix_factorization/toeplitz_test.py
+++ b/tests/matrix_factorization/toeplitz_test.py
@@ -146,6 +146,58 @@ class ToeplitzTest(parameterized.TestCase):
         atol=1e-6,
     )
 
+  def test_banded_inverse_square_root_noising_coefs(self):
+    np.testing.assert_allclose(
+        toeplitz.banded_inverse_square_root_noising_coefs(5),
+        jnp.array([1, -1 / 2, -1 / 8, -1 / 16, -5 / 128]),
+        atol=1e-6,
+    )
+
+  @parameterized.named_parameters((f'{k=}', k) for k in [1, 2, 4, 8, 16])
+  def test_banded_inverse_sensitivity_squared_matches_toeplitz(
+      self, max_participations
+  ):
+    num_bands = 8
+    n = 128
+    min_sep = n // max_participations
+
+    noising_coef = toeplitz.banded_inverse_square_root_noising_coefs(num_bands)
+    strategy_coef = toeplitz.inverse_coef(noising_coef, n=n)
+
+    projected_sensitivity_squared = toeplitz.compute_banded_inverse_sensitivity_squared(
+            n=n,
+            noising_coef=noising_coef,
+            min_sep=min_sep,
+            max_participations=max_participations,
+            use_matrix_upper_bound=False,
+    )
+    matrix_sensitivity_squared = (
+        toeplitz.compute_banded_inverse_sensitivity_squared(
+            n=n,
+            noising_coef=noising_coef,
+            min_sep=min_sep,
+            max_participations=max_participations,
+            use_matrix_upper_bound=True,
+        )
+    )
+    toeplitz_sensitivity_squared = toeplitz.minsep_sensitivity_squared(
+        strategy_coef,
+        min_sep=min_sep,
+        max_participations=max_participations,
+        n=n,
+    )
+
+    np.testing.assert_allclose(
+        projected_sensitivity_squared,
+        toeplitz_sensitivity_squared,
+        atol=1e-6,
+    )
+    np.testing.assert_allclose(
+        matrix_sensitivity_squared,
+        toeplitz_sensitivity_squared,
+        atol=1e-6,
+    )
+
   @parameterized.named_parameters(
       ('full', 16, 16),
       ('basic', 15, 6),
@@ -461,6 +513,74 @@ class ToeplitzOptimizationTest(parameterized.TestCase):
         toeplitz.loss(strategy_coef=coef2, n=16),
         toeplitz.loss(strategy_coef=coef1, n=16),
     )
+
+  @parameterized.named_parameters((f'{k=}', k) for k in [1, 2, 4, 8, 16])
+  def test_optimize_banded_inverse_toeplitz_improves_over_bisr(
+      self, max_participations
+  ):
+    n = 128
+    min_sep = n // max_participations
+    num_bands = 8
+    weight_decay = 1.0
+    momentum = 0.0
+
+    workload_coef = toeplitz.multiply(
+        weight_decay ** jnp.arange(n),
+        momentum ** jnp.arange(n),
+        n=n,
+        skip_checks=True,
+    )
+
+    optimized_coef = toeplitz.optimize_banded_inverse_toeplitz(
+        n=n,
+        min_sep=min_sep,
+        num_bands=num_bands,
+        max_participations=max_participations,
+        weight_decay=weight_decay,
+        momentum=momentum,
+        max_optimizer_steps=100,
+        reduction_fn=jnp.mean,
+    )
+    bisr_coef = toeplitz.banded_inverse_square_root_noising_coefs(
+        num_bands, weight_decay=weight_decay, momentum=momentum
+    )
+
+    self.assertTrue(jnp.all(jnp.isfinite(optimized_coef)))
+    np.testing.assert_allclose(optimized_coef[0], 1.0, atol=1e-6)
+
+    optimized_error = jnp.mean(
+        toeplitz.per_query_error(
+            noising_coef=optimized_coef,
+            n=n,
+            workload_coef=workload_coef,
+        )
+    )
+    optimized_sensitivity_squared = (
+        toeplitz.compute_banded_inverse_sensitivity_squared(
+            n=n,
+            noising_coef=optimized_coef,
+            min_sep=min_sep,
+            max_participations=max_participations,
+        )
+    )
+    optimized_loss = optimized_error * optimized_sensitivity_squared
+
+    bisr_error = jnp.mean(
+        toeplitz.per_query_error(
+            noising_coef=bisr_coef,
+            n=n,
+            workload_coef=workload_coef,
+        )
+    )
+    bisr_sensitivity_squared = toeplitz.compute_banded_inverse_sensitivity_squared(
+        n=n,
+        noising_coef=bisr_coef,
+        min_sep=min_sep,
+        max_participations=max_participations,
+    )
+    bisr_loss = bisr_error * bisr_sensitivity_squared
+
+    self.assertLessEqual(optimized_loss, bisr_loss)
 
 
 class ToeplitzAmplificationTest(parameterized.TestCase):

--- a/tests/matrix_factorization/toeplitz_test.py
+++ b/tests/matrix_factorization/toeplitz_test.py
@@ -553,10 +553,6 @@ class ToeplitzOptimizationTest(parameterized.TestCase):
     self.assertTrue(jnp.all(jnp.isfinite(optimized_coef)))
     np.testing.assert_allclose(optimized_coef[0], 1.0, atol=1e-6)
 
-    # Make per_query_error handle banded inverse coefficients correctly.
-    if workload_coef is None:
-      workload_coef = jnp.ones(n)
-
     optimized_error = jnp.mean(
         toeplitz.per_query_error(
             noising_coef=optimized_coef,

--- a/tests/matrix_factorization/toeplitz_test.py
+++ b/tests/matrix_factorization/toeplitz_test.py
@@ -523,14 +523,21 @@ class ToeplitzOptimizationTest(parameterized.TestCase):
         toeplitz.loss(strategy_coef=coef1, n=16),
     )
 
-  @parameterized.named_parameters((f'{k=}', k) for k in [1, 2, 4, 8, 16])
+  @parameterized.product(
+      max_participations=[1, 2, 4, 8, 16],
+      momentum=[None, 0.0, 0.9],
+  )
   def test_optimize_banded_inverse_toeplitz_improves_over_bisr(
-      self, max_participations
+      self, max_participations, momentum
   ):
     n = 128
     min_sep = n // max_participations
     num_bands = 8
-    workload_coef = jnp.ones(n)
+    if momentum is None:
+      workload_coef = None
+    else:
+      decay = jnp.asarray(momentum ** np.arange(n))
+      workload_coef = toeplitz.multiply(jnp.ones(n), decay, n=n)
 
     optimized_coef = toeplitz.optimize_banded_inverse_toeplitz(
         n=n,
@@ -545,6 +552,10 @@ class ToeplitzOptimizationTest(parameterized.TestCase):
 
     self.assertTrue(jnp.all(jnp.isfinite(optimized_coef)))
     np.testing.assert_allclose(optimized_coef[0], 1.0, atol=1e-6)
+
+    # Make per_query_error handle banded inverse coefficients correctly.
+    if workload_coef is None:
+      workload_coef = jnp.ones(n)
 
     optimized_error = jnp.mean(
         toeplitz.per_query_error(


### PR DESCRIPTION
Resolves #202

This PR adds support for BandInvMF and BISR, based on banded inverse lower-triangular Toeplitz matrices, from https://arxiv.org/pdf/2505.12128.

Changes:
- add `banded_inverse_square_root_noising_coefs(...)` in `toeplitz.py`
- add `compute_banded_inverse_sensitivity(...)` for banded inverse lower-triangular Toeplitz noising matrices
- add `optimize_banded_inverse_toeplitz(...)` for direct optimization over banded inverse lower-triangular Toeplitz noising coefficients
- extend `examples/dpmf_strategy_optimization.py` with:
  - `banded-inverse-toeplitz`
  - `banded-inverse-sqrt`