### PR TITLE
Fix clipped_fun return_norms output contract

### DIFF
--- a/jax_privacy/clipping.py
+++ b/jax_privacy/clipping.py
@@ -38,7 +38,7 @@ class BoundedSensitivityCallable:
   """Callable with a sensitivity property.
 
   If has_aux is False, the sensitivity guarantee holds for the entire output
-  which may be an arbitrary PyTree of JAX Arrays.  If has_aux is False, the
+  which may be an arbitrary PyTree of JAX Arrays.  If has_aux is True, the
   output of the function is a pair `(value, aux)` and the sensitivity guarantee
   only holds for `value` PyTree. The aux PyTree is returned on a per-example
   basis (i.e., as a PyTree of arrays having a batch axis).  The caller should
@@ -413,8 +413,8 @@ def clipped_fun(
   norm_bound = (1.0 if rescale_to_unit_norm else l2_clip_norm) / normalize_by
   if keep_batch_dim:
     clipped_fn = _with_extra_batch_axis(clipped_fn, batch_argnums)
-  has_aux = has_aux or return_norms
-  return BoundedSensitivityCallable(clipped_fn, norm_bound, has_aux)
+  callable_has_aux = has_aux or return_norms
+  return BoundedSensitivityCallable(clipped_fn, norm_bound, callable_has_aux)
 
 
 def _validate_static_args(argnums, batch_argnums, normalize_by):

--- a/tests/clipping_test.py
+++ b/tests/clipping_test.py
@@ -208,6 +208,23 @@ class ClipTransformTest(parameterized.TestCase):
     relation = dp_accounting.NeighboringRelation.REPLACE_ONE
     self.assertLessEqual(diff, sum_clip_mean.sensitivity(relation) + 1e-6)
 
+  def test_return_norms_without_aux_matches_documented_signature(self):
+
+    def fun(x):
+      return x**2
+
+    sum_clip = clipping.clipped_fun(
+        fun,
+        batch_argnums=0,
+        keep_batch_dim=False,
+        l2_clip_norm=jnp.inf,
+        return_norms=True,
+    )
+
+    value, norms = sum_clip(jnp.array([1.0, 2.0, 3.0]))
+    chex.assert_trees_all_close(value, 14.0)
+    chex.assert_trees_all_close(norms, jnp.array([1.0, 4.0, 9.0]))
+
   @parameterized.product(
       arg_dtype=[jnp.float16, jnp.bfloat16, jnp.float32],
       output_dtype=[jnp.float32, None],


### PR DESCRIPTION
This fixes the runtime contract of `clipped_fun(..., return_norms=True)` when `has_aux=False`.

Right now the function documents that this configuration should return `(value, norms)`, but the implementation mutates `has_aux` after defining the closure. Because the closure sees that mutated value, callers can get `(value, ((), norms))` instead.

The fix keeps the original `has_aux` value for runtime behavior and uses a separate flag only for the `BoundedSensitivityCallable` metadata.

I also added a regression test that checks the documented `(value, norms)` shape directly.

Validation:

```bash
PYTHONPATH=. python -m pytest -q tests/clipping_test.py
```
