### PR TITLE
Fix multi-participation sensitivity calculation for banded Toeplitz strategies

### DIFF
--- a/examples/dpmf_strategy_optimization.py
+++ b/examples/dpmf_strategy_optimization.py
@@ -100,6 +100,7 @@ def optimize_strategy(
       strategy_coef = toeplitz.optimize_banded_toeplitz(
           n, bands=sep, max_optimizer_steps=1000, reduction_fn=reduction_fn
       )
+      strategy_coef = jnp.pad(strategy_coef, (0, n - len(strategy_coef)))
       sensitivity_squared = toeplitz.minsep_sensitivity_squared(
           strategy_coef, min_sep=sep, max_participations=participations
       )
@@ -141,6 +142,7 @@ def optimize_strategy(
       strategy_coef = optimization.optimize(
           loss_fn, initial_strategy_coef, max_optimizer_steps=1000
       )
+      strategy_coef = jnp.pad(strategy_coef, (0, n - len(strategy_coef)))
 
       # this is just equal to # participations
       sensitivity_squared = toeplitz.minsep_sensitivity_squared(
@@ -155,6 +157,7 @@ def optimize_strategy(
       # https://arxiv.org/abs/2202.11205
       # https://arxiv.org/abs/2405.13763
       strategy_coef = toeplitz.optimal_max_error_strategy_coefs(sep)
+      strategy_coef = jnp.pad(strategy_coef, (0, n - len(strategy_coef)))
       sensitivity_squared = toeplitz.minsep_sensitivity_squared(
           strategy_coef, min_sep=sep, max_participations=participations
       )

--- a/examples/dpmf_strategy_optimization.py
+++ b/examples/dpmf_strategy_optimization.py
@@ -100,9 +100,8 @@ def optimize_strategy(
       strategy_coef = toeplitz.optimize_banded_toeplitz(
           n, bands=sep, max_optimizer_steps=1000, reduction_fn=reduction_fn
       )
-      strategy_coef = jnp.pad(strategy_coef, (0, n - len(strategy_coef)))
       sensitivity_squared = toeplitz.minsep_sensitivity_squared(
-          strategy_coef, min_sep=sep, max_participations=participations
+          strategy_coef, n=n, min_sep=sep, max_participations=participations
       )
       pqe = toeplitz.per_query_error(strategy_coef=strategy_coef, n=n)
       loss = reduction_fn(pqe) * sensitivity_squared
@@ -142,12 +141,12 @@ def optimize_strategy(
       strategy_coef = optimization.optimize(
           loss_fn, initial_strategy_coef, max_optimizer_steps=1000
       )
-      strategy_coef = jnp.pad(strategy_coef, (0, n - len(strategy_coef)))
 
       # this is just equal to # participations
       sensitivity_squared = toeplitz.minsep_sensitivity_squared(
           # Strategy is normalized in toeplitz.inverse_as_streaming_matrix.
           strategy_coef=strategy_coef / jnp.linalg.norm(strategy_coef),
+          n=n,
           min_sep=sep,
           max_participations=participations,
       )
@@ -157,9 +156,8 @@ def optimize_strategy(
       # https://arxiv.org/abs/2202.11205
       # https://arxiv.org/abs/2405.13763
       strategy_coef = toeplitz.optimal_max_error_strategy_coefs(sep)
-      strategy_coef = jnp.pad(strategy_coef, (0, n - len(strategy_coef)))
       sensitivity_squared = toeplitz.minsep_sensitivity_squared(
-          strategy_coef, min_sep=sep, max_participations=participations
+          strategy_coef, n=n, min_sep=sep, max_participations=participations
       )
       pqe = toeplitz.per_query_error(strategy_coef=strategy_coef, n=n)
       loss = reduction_fn(pqe) * sensitivity_squared

--- a/jax_privacy/matrix_factorization/buffered_toeplitz.py
+++ b/jax_privacy/matrix_factorization/buffered_toeplitz.py
@@ -658,6 +658,7 @@ class LossFn:
       return toeplitz.minsep_sensitivity_squared(
           strategy_coef=blt.toeplitz_coefs(n),
           min_sep=min_sep,
+          n=n,
           max_participations=max_participations,
       )
 

--- a/jax_privacy/matrix_factorization/toeplitz.py
+++ b/jax_privacy/matrix_factorization/toeplitz.py
@@ -303,8 +303,9 @@ def sensitivity_squared(coef: jax.Array, n: int | None = None) -> jax.Array:
 def minsep_sensitivity_squared(
     strategy_coef: jax.Array,
     min_sep: int,
+    *,
+    n: int,
     max_participations: int | None = None,
-    n: int | None = None,
 ) -> jax.Array:
   """Returns the sensitivity of the Toeplitz matrix.
 
@@ -332,9 +333,8 @@ def minsep_sensitivity_squared(
       training](https://arxiv.org/abs/2306.08153). For a user participating on
       iteration $i$ and then again on iteration $j$,  the separation is $j -i$;
       that is, a min_sep of 1 allows participation on every iteration.
+    n: The size of the matrix C (see `coef` above).
     max_participations: The maximum participation of a worst-case user.
-    n: Optional, the size of the matrix C (see `coef` above). If None, the size
-      of the matrix is equal to the number of coefficients.
 
   Returns:
     The sensitivity squared. This is exact when `strategy_coef` is non-negative

--- a/tests/matrix_factorization/buffered_toeplitz_test.py
+++ b/tests/matrix_factorization/buffered_toeplitz_test.py
@@ -131,6 +131,7 @@ def brute_force_max_loss(blt, n, min_sep=1, max_participations=None):
   sens_squared = toeplitz.minsep_sensitivity_squared(
       coef,
       min_sep=min_sep,
+      n=n,
       max_participations=max_participations,
   )
   error = jnp.max(toeplitz.per_query_error(strategy_coef=coef))

--- a/tests/matrix_factorization/toeplitz_test.py
+++ b/tests/matrix_factorization/toeplitz_test.py
@@ -380,9 +380,7 @@ class ToeplitzTest(parameterized.TestCase):
 
   def test_sensitivity_squared_bad_min_sep(self):
     with self.assertRaisesRegex(ValueError, 'min_sep must be positive'):
-      toeplitz.minsep_sensitivity_squared(
-          strategy_coef=[1.0], min_sep=0, n=1
-      )
+      toeplitz.minsep_sensitivity_squared(strategy_coef=[1.0], min_sep=0, n=1)
 
   @parameterized.product(
       coef=[[-1.0], [1.0, 2.0, 1.0], [1.0, -0.5, 0.3], [-1, 0.5]],

--- a/tests/matrix_factorization/toeplitz_test.py
+++ b/tests/matrix_factorization/toeplitz_test.py
@@ -372,7 +372,7 @@ class ToeplitzTest(parameterized.TestCase):
     C = toeplitz.materialize_lower_triangular(coef)
     np.testing.assert_allclose(
         toeplitz.minsep_sensitivity_squared(
-            coef, min_sep=1, max_participations=max_participations
+            coef, min_sep=1, n=n, max_participations=max_participations
         ),
         np.linalg.norm(np.sum(C[:, :max_participations], axis=1)) ** 2,
         rtol=1e-10,
@@ -380,7 +380,9 @@ class ToeplitzTest(parameterized.TestCase):
 
   def test_sensitivity_squared_bad_min_sep(self):
     with self.assertRaisesRegex(ValueError, 'min_sep must be positive'):
-      toeplitz.minsep_sensitivity_squared(strategy_coef=[1.0], min_sep=0)
+      toeplitz.minsep_sensitivity_squared(
+          strategy_coef=[1.0], min_sep=0, n=1
+      )
 
   @parameterized.product(
       coef=[[-1.0], [1.0, 2.0, 1.0], [1.0, -0.5, 0.3], [-1, 0.5]],


### PR DESCRIPTION
This PR fixes an inconsistency in the multi-participation sensitivity calculation in `examples/dpmf_strategy_optimization.py.
`

For the ` banded-toeplitz`, `banded-sqrt`, and `normalized-banded-toeplitz` methods, `strategy_coefficients` were computed with length `sep` and then passed to `toeplitz.minsep_sensitivity_squared`. Since that function infers the matrix size from the provided coefficients, it treated the number of iterations as `sep` rather than `n`.

As a result, the squared sensitivity was underestimated by a factor of `participations`, making the reported RMSE inconsistent with the `blt`, `dense`, and `banded-inverse` methods.

The fix pads the strategy coefficients to length `n` before calling `toeplitz.minsep_sensitivity_squared`, ensuring that the sensitivity is computed for the intended number of iterations.