### PR TITLE
Guard against ZeroDivisionError for noise_multiplier=0 with use_zcdp=True

### DIFF
--- a/jax_privacy/accounting.py
+++ b/jax_privacy/accounting.py
@@ -109,7 +109,8 @@ def _gaussian_event(
 ) -> dp_accounting.DpEvent:
   """Returns the Gaussian or zCDP DpEvent for the given noise multiplier."""
   if use_zcdp:
-    return dp_accounting.ZCDpEvent(0.5 / noise_multiplier**2)
+    rho = math.inf if noise_multiplier == 0 else 0.5 / noise_multiplier**2
+    return dp_accounting.ZCDpEvent(rho)
   else:
     return dp_accounting.GaussianDpEvent(noise_multiplier)
 

--- a/tests/accounting_test.py
+++ b/tests/accounting_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import functools
+import math
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -179,6 +180,27 @@ class AccountingTest(parameterized.TestCase):
     inner = event.event.event
     self.assertIsInstance(inner, dp_accounting.dp_event.ZCDpEvent)
     self.assertAlmostEqual(inner.rho, 0.5 / noise_multiplier**2)
+
+  def test_dpsgd_event_zero_noise_does_not_crash(self):
+    """noise_multiplier=0 is permitted and must not raise in either branch.
+
+    `_validate_args` only rejects negative noise multipliers, so 0.0 is a valid
+    input denoting infinite privacy loss. The continuous branch already handles
+    it via GaussianDpEvent(0); the zCDP branch must likewise not raise a
+    ZeroDivisionError from 0.5 / noise_multiplier**2 and should report rho=inf.
+    """
+    continuous = accounting.dpsgd_event(0.0, 10, sampling_prob=0.01)
+    self.assertIsInstance(
+        continuous.event.event, dp_accounting.dp_event.GaussianDpEvent
+    )
+    self.assertEqual(continuous.event.event.noise_multiplier, 0.0)
+
+    discrete = accounting.dpsgd_event(
+        0.0, 10, sampling_prob=0.01, use_zcdp=True
+    )
+    inner = discrete.event.event
+    self.assertIsInstance(inner, dp_accounting.dp_event.ZCDpEvent)
+    self.assertTrue(math.isinf(inner.rho))
 
   def test_use_zcdp_matches_gaussian_privacy(self):
     """use_zcdp=True & default should give the same epsilon with RDP."""


### PR DESCRIPTION
## Bug

`experimental.accounting._validate_args` permits `noise_multiplier >= 0`, and the continuous branch handles `GaussianDpEvent(0)` gracefully, but the zCDP branch computes `0.5 / noise_multiplier**2` and raises an opaque `ZeroDivisionError` on the validated-as-legal input `noise_multiplier=0`:

```python
>>> dpsgd_event(0.0, 1, sampling_prob=1.0, use_zcdp=True)
ZeroDivisionError: float division by zero
```

## Fix

Guard the division and return `ZCDpEvent(inf)` (ρ → ∞, i.e. no privacy) for `noise_multiplier=0`, matching the degenerate semantics already implied by the continuous branch. No `noise_multiplier > 0` result changes. Adds a regression test covering both branches.

## Testing
`tests/experimental/accounting_test.py` — pass. The new `test_dpsgd_event_zero_noise_does_not_crash` errors with `ZeroDivisionError` on the pre-fix code; existing zCDP structure tests are unaffected.
