### PR TITLE
docs(keras_api): correct train_steps formula to account for gradient accumulation

### DIFF
--- a/jax_privacy/keras_api.py
+++ b/jax_privacy/keras_api.py
@@ -99,10 +99,17 @@ class DPKerasConfig:
         to memory constraints, therefore gradient accumulation technique is very
         useful during DP training.
       train_steps: The number of training steps (optimizer update steps). If you
-        try to train the model for more steps, it will fail. If you train by
-        epochs, then it is epochs * (train_size // batch_size). If you train
-        while the dataset iterator is not over then it is the length of the
-        dataset iterator.
+        try to train the model for more steps, it will fail. Because one
+        optimizer update consumes `gradient_accumulation_steps` batches, this is
+        the number of optimizer updates, not the number of (micro-)batches. If
+        you train by epochs, then it is
+        epochs * (train_size // effective_batch_size), where
+        effective_batch_size = batch_size * gradient_accumulation_steps (this
+        reduces to epochs * (train_size // batch_size) only when
+        gradient_accumulation_steps == 1). If you train while the dataset
+        iterator is not over, then it is the number of optimizer updates the
+        iterator produces, i.e. its (micro-)batch length //
+        gradient_accumulation_steps.
       train_size: The number of training examples in the dataset. If you repeat
         the examples in your dataset iterator, it should be the number of
         training examples in the original dataset before repeating.

--- a/jax_privacy/keras_api.py
+++ b/jax_privacy/keras_api.py
@@ -102,14 +102,13 @@ class DPKerasConfig:
         try to train the model for more steps, it will fail. Because one
         optimizer update consumes `gradient_accumulation_steps` batches, this is
         the number of optimizer updates, not the number of (micro-)batches. If
-        you train by epochs, then it is
-        epochs * (train_size // effective_batch_size), where
-        effective_batch_size = batch_size * gradient_accumulation_steps (this
-        reduces to epochs * (train_size // batch_size) only when
-        gradient_accumulation_steps == 1). If you train while the dataset
-        iterator is not over, then it is the number of optimizer updates the
-        iterator produces, i.e. its (micro-)batch length //
-        gradient_accumulation_steps.
+        you train by epochs, then it is epochs * (train_size //
+        effective_batch_size), where effective_batch_size = batch_size *
+        gradient_accumulation_steps (this reduces to epochs * (train_size //
+        batch_size) only when gradient_accumulation_steps == 1). If you train
+        while the dataset iterator is not over, then it is the number of
+        optimizer updates the iterator produces, i.e. its (micro-)batch length
+        // gradient_accumulation_steps.
       train_size: The number of training examples in the dataset. If you repeat
         the examples in your dataset iterator, it should be the number of
         training examples in the original dataset before repeating.


### PR DESCRIPTION
## Summary

The `DPKerasConfig.train_steps` docstring contradicts itself, which is the root cause of the confusion reported in #234.

- Line: *"`train_steps`: The number of training steps (**optimizer update steps**)"*
- But the formula it gives is `epochs * (train_size // batch_size)`, which is the number of **(micro-)batches**, not optimizer updates.

These only agree when `gradient_accumulation_steps == 1`. With gradient accumulation, one optimizer update consumes `gradient_accumulation_steps` batches, so the documented formula is `gradient_accumulation_steps`× too large. A user who follows it passes an inflated step count to the accountant — exactly the discrepancy in #234, where two runs with the same effective batch size but different `gradient_accumulation_steps` produced different noise multipliers (7.69 vs 3.92).

## Fix

Documentation only. Correct the epochs formula to use the **effective** batch size and clarify the iterator case:

```
epochs * (train_size // effective_batch_size),
  where effective_batch_size = batch_size * gradient_accumulation_steps
```

## Why docs, not the accounting code

The privacy accountant is **correct**: it uses `train_steps` as the number of privatized optimizer updates (`iterations=self.train_steps`), which is the right composition count for DP accounting. Changing the accountant to divide `train_steps` by `gradient_accumulation_steps` would *under-count* iterations and **silently weaken the privacy guarantee** — so the bug is in the docstring formula, not the math. This change carries no behavioral or privacy risk.

Addresses #234.
