### PR TITLE
Add functionality for per-layer clipping

### DIFF
--- a/jax_privacy/clipping.py
+++ b/jax_privacy/clipping.py
@@ -82,14 +82,22 @@ class BoundedSensitivityCallable:
 def clip_pytree(
     pytree: PyTree,
     clip_norm: float,
+    per_leaf: bool = False,
     rescale_to_unit_norm: bool = False,
     nan_safe: bool = True,
     return_zero: bool = False,
 ):
-  """Clips a PyTree of jax arrays based on its global L2 norm.
+  """Clips a PyTree of jax arrays based on its global L2 norm or per leaf L2 norm.
 
-  Calculates the global L2 norm of the input PyTree. If the norm exceeds
-  `clip_norm`, the PyTree is scaled down to have norm equal to `clip_norm`.
+  If per_leaf is False:
+      Calculates the global L2 norm of the input PyTree. If the norm exceeds
+    `clip_norm`, the entire PyTree is scaled down to have norm equal to
+    `clip_norm`.
+  If per_leaf is True:
+    Calculate the L2 norm for each leaf of the input PyTree. If the norm
+    per leaf exceeds `clip_norm`, the said leaf is scaled down to have the
+    norm equal to the `clip_norm`.
+
   If `rescale_to_unit_norm` is True, the PyTree is additionally scaled by
   `1.0 / clip_norm` (resulting in a norm of at most 1.0 no matter
   what clip_norm is). Handles cases where the original norm is zero,
@@ -140,13 +148,30 @@ def clip_pytree(
     nan_to_num = lambda x: jnp.nan_to_num(x, nan=0.0, posinf=0.0, neginf=0.0)
     pytree = jax.tree.map(nan_to_num, pytree)
   clip_norm = jnp.maximum(clip_norm, 0.0)
-  l2_norm = optax.tree.norm(pytree)
-  scale = jnp.minimum(1.0, clip_norm / l2_norm)
-  if rescale_to_unit_norm:
-    scale = jax.lax.select(clip_norm > 0, scale / clip_norm, 1 / l2_norm)
-  # If l2_norm is 0 or nan, set scale to 0.0.
-  scale = jnp.nan_to_num(scale, nan=0.0, posinf=0.0)
-  clipped = jax.tree.map(lambda x: jnp.astype(scale, x.dtype) * x, pytree)
+
+  if per_leaf:
+      def _clip_single_leaf(leaf):
+        l2_norm_leaf = jnp.linalg.norm(leaf)
+        scale = jnp.minimum(1.0, clip_norm / l2_norm_leaf)
+        if rescale_to_unit_norm:
+          scale = jax.lax.select(clip_norm > 0, scale / clip_norm, 1.0 / l2_norm_leaf)
+        scale = jnp.nan_to_num(scale, nan=0.0, posinf=0.0)
+        clipped_leaf = jnp.astype(scale, leaf.dtype) * leaf
+        return clipped_leaf, l2_norm_leaf.astype(jnp.float32)
+
+      results_tree = jax.tree.map(lambda l: _clip_single_leaf(l, clip_norm), pytree)
+      clipped = jax.tree.map(lambda r: r[0], results_tree)
+      l2_norms_per_leaf = jax.tree.map(lambda r: r[1], results_tree)
+      l2_norm = jnp.sqrt(sum(n**2 for n in l2_norms_per_leaf))
+  else:
+    l2_norm = optax.global_norm(pytree)
+    scale = jnp.minimum(1.0, clip_norm / l2_norm)
+    if rescale_to_unit_norm:
+      scale = jax.lax.select(clip_norm > 0, scale / clip_norm, 1 / l2_norm)
+    # If l2_norm is 0 or nan, set scale to 0.0.
+    scale = jnp.nan_to_num(scale, nan=0.0, posinf=0.0)
+    clipped = jax.tree.map(lambda x: jnp.astype(scale, x.dtype) * x, pytree)
+
   maybe_zero = lambda x: jax.lax.select(return_zero, jnp.zeros_like(x), x)
   return jax.tree.map(maybe_zero, clipped), l2_norm.astype(jnp.float32)
 
@@ -363,6 +388,7 @@ def clipped_fun(
     *,
     batch_argnums: int | Sequence[int] = 0,
     keep_batch_dim: bool = True,
+    per_layer: bool = False,
     l2_clip_norm: float = 1.0,
     rescale_to_unit_norm: bool = False,
     normalize_by: float = 1.0,
@@ -402,6 +428,11 @@ def clipped_fun(
       the value will be clipped + aggregated, `aux` will be returned on a
       per-example basis. Exercise caution when using this as the sensitivity
       guarantees of the returned Callable are only provided w.r.t. `value`.
+    per_layer: If True, the gradient clipping is performed on each leaf of the
+      PyTree. Rather than calculating a global L2 norm, the norm is calculated
+      & clipping threshold is applied on each parameter array of the PyTree.
+      Currently supports a single value (passed via l2_clip_norm), and applies
+      the same value across all leaves.
     batch_argnums: Specifies which argument(s) of `fun` contain the batch
       dimension. All arguments specified here must have the same size along the
       0th axis.
@@ -491,6 +522,7 @@ def clipped_fun(
         value = optax.tree.cast(value, dtype)
         clipped_value, l2_norm = clip_pytree(
             value,
+            per_leaf=per_layer,
             clip_norm=l2_clip_norm,
             rescale_to_unit_norm=rescale_to_unit_norm,
             nan_safe=nan_safe,
@@ -583,6 +615,7 @@ def clipped_grad(
     argnums: int | Sequence[int] = 0,
     has_aux: bool = False,
     *,
+    per_layer: bool = False,
     l2_clip_norm: float,
     rescale_to_unit_norm: bool = False,
     normalize_by: float = 1.0,
@@ -665,6 +698,11 @@ def clipped_grad(
       auxiliary data `aux` will be returned by the transformed function.
       Exercise caution when using this as no DP sensitivity guarantees are
       provided for the auxiliary data.
+    per_layer: If True, the gradient clipping is performed on each leaf of the
+      PyTree. Rather than calculating a global L2 norm, the norm is calculated
+      & clipping threshold is applied on each parameter array of the PyTree.
+      Currently supports a single value (passed via l2_clip_norm), and applies
+      the same value across all leaves.
     l2_clip_norm: The maximum L2 norm for each per-example gradient. Gradients
       with a norm larger than this value will be scaled down.
     rescale_to_unit_norm: If True, clipped gradients are rescaled by `1.0 /
@@ -753,6 +791,7 @@ def clipped_grad(
       grad_fn,
       has_aux=has_aux or return_values or return_grad_norms,
       batch_argnums=batch_argnums,
+      per_layer=per_layer,
       l2_clip_norm=l2_clip_norm,
       keep_batch_dim=keep_batch_dim,
       rescale_to_unit_norm=rescale_to_unit_norm,

--- a/jax_privacy/clipping.py
+++ b/jax_privacy/clipping.py
@@ -28,7 +28,6 @@ import jax.numpy as jnp
 import optax
 from optax import microbatching
 
-
 PyTree: TypeAlias = chex.ArrayTree
 AuxiliaryOutput = collections.namedtuple('Aux', ['values', 'grad_norms', 'aux'])
 _REPLACE_SPECIAL = dp_accounting.NeighboringRelation.REPLACE_SPECIAL
@@ -87,10 +86,10 @@ def clip_pytree(
     nan_safe: bool = True,
     return_zero: bool = False,
 ):
-  """Clips a PyTree of jax arrays based on its global L2 norm or per leaf L2 norm.
+  """Clips a PyTree of jax arrays.
 
   If per_leaf is False:
-      Calculates the global L2 norm of the input PyTree. If the norm exceeds
+    Calculates the global L2 norm of the input PyTree. If the norm exceeds
     `clip_norm`, the entire PyTree is scaled down to have norm equal to
     `clip_norm`.
   If per_leaf is True:
@@ -149,31 +148,37 @@ def clip_pytree(
     pytree = jax.tree.map(nan_to_num, pytree)
   clip_norm = jnp.maximum(clip_norm, 0.0)
 
-  if per_leaf:
-      def _clip_single_leaf(leaf):
-        l2_norm_leaf = jnp.linalg.norm(leaf)
-        scale = jnp.minimum(1.0, clip_norm / l2_norm_leaf)
-        if rescale_to_unit_norm:
-          scale = jax.lax.select(clip_norm > 0, scale / clip_norm, 1.0 / l2_norm_leaf)
-        scale = jnp.nan_to_num(scale, nan=0.0, posinf=0.0)
-        clipped_leaf = jnp.astype(scale, leaf.dtype) * leaf
-        return clipped_leaf, l2_norm_leaf.astype(jnp.float32)
-
-      results_tree = jax.tree.map(lambda l: _clip_single_leaf(l, clip_norm), pytree)
-      clipped = jax.tree.map(lambda r: r[0], results_tree)
-      l2_norms_per_leaf = jax.tree.map(lambda r: r[1], results_tree)
-      l2_norm = jnp.sqrt(sum(n**2 for n in l2_norms_per_leaf))
-  else:
-    l2_norm = optax.global_norm(pytree)
+  def _calculate_scale(l2_norm):
     scale = jnp.minimum(1.0, clip_norm / l2_norm)
     if rescale_to_unit_norm:
-      scale = jax.lax.select(clip_norm > 0, scale / clip_norm, 1 / l2_norm)
+      scale = jax.lax.select(clip_norm > 0, scale / clip_norm, 1.0 / l2_norm)
     # If l2_norm is 0 or nan, set scale to 0.0.
     scale = jnp.nan_to_num(scale, nan=0.0, posinf=0.0)
+    return scale
+
+  if per_leaf:
+    leaves, treedef = jax.tree.flatten(pytree)
+    clipped_leaves = []
+    norm_leaves = []
+    for leaf in leaves:
+      l2_norm_leaf = jnp.linalg.norm(leaf)
+      scale = _calculate_scale(l2_norm_leaf)
+      clipped_leaves.append(jnp.astype(scale, leaf.dtype) * leaf)
+      norm_leaves.append(l2_norm_leaf.astype(jnp.float32))
+
+    clipped = jax.tree.unflatten(treedef, clipped_leaves)
+
+    # The list of norms for each leaf, norm_leaves, is used to artificially
+    # construct the l2_norm.
+    l2_norm = jnp.sqrt(jnp.sum(jnp.stack(norm_leaves) ** 2))
+  else:
+    l2_norm = optax.global_norm(pytree)
+    scale = _calculate_scale(l2_norm)
     clipped = jax.tree.map(lambda x: jnp.astype(scale, x.dtype) * x, pytree)
+    l2_norm = l2_norm.astype(jnp.float32)
 
   maybe_zero = lambda x: jax.lax.select(return_zero, jnp.zeros_like(x), x)
-  return jax.tree.map(maybe_zero, clipped), l2_norm.astype(jnp.float32)
+  return jax.tree.map(maybe_zero, clipped), l2_norm
 
 
 def _adjusted_clip_norm(
@@ -388,8 +393,8 @@ def clipped_fun(
     *,
     batch_argnums: int | Sequence[int] = 0,
     keep_batch_dim: bool = True,
-    per_layer: bool = False,
     l2_clip_norm: float = 1.0,
+    per_layer: bool = False,
     rescale_to_unit_norm: bool = False,
     normalize_by: float = 1.0,
     return_norms: bool = False,
@@ -428,11 +433,6 @@ def clipped_fun(
       the value will be clipped + aggregated, `aux` will be returned on a
       per-example basis. Exercise caution when using this as the sensitivity
       guarantees of the returned Callable are only provided w.r.t. `value`.
-    per_layer: If True, the gradient clipping is performed on each leaf of the
-      PyTree. Rather than calculating a global L2 norm, the norm is calculated
-      & clipping threshold is applied on each parameter array of the PyTree.
-      Currently supports a single value (passed via l2_clip_norm), and applies
-      the same value across all leaves.
     batch_argnums: Specifies which argument(s) of `fun` contain the batch
       dimension. All arguments specified here must have the same size along the
       0th axis.
@@ -440,6 +440,11 @@ def clipped_fun(
       batch axis of size 1.  If False, this size 1 axis will be dropped
       (reducing the rank of the batch args by 1 before passing to `fun`).
     l2_clip_norm: The maximum L2 norm allowed.
+    per_layer: If True, the gradient clipping is performed on each leaf of the
+      PyTree. Rather than calculating a global L2 norm, the norm is calculated &
+      clipping threshold is applied on each parameter array of the PyTree.
+      Currently supports a single value (passed via l2_clip_norm), and applies
+      the same value across all leaves.
     rescale_to_unit_norm: If True, the output PyTree's norm is rescaled by `1.0
       / clip_norm` after potential clipping. If False, the output PyTree has
       norm at most `clip_norm`.
@@ -615,8 +620,8 @@ def clipped_grad(
     argnums: int | Sequence[int] = 0,
     has_aux: bool = False,
     *,
-    per_layer: bool = False,
     l2_clip_norm: float,
+    per_layer: bool = False,
     rescale_to_unit_norm: bool = False,
     normalize_by: float = 1.0,
     batch_argnums: int | Sequence[int] = 1,
@@ -698,13 +703,13 @@ def clipped_grad(
       auxiliary data `aux` will be returned by the transformed function.
       Exercise caution when using this as no DP sensitivity guarantees are
       provided for the auxiliary data.
-    per_layer: If True, the gradient clipping is performed on each leaf of the
-      PyTree. Rather than calculating a global L2 norm, the norm is calculated
-      & clipping threshold is applied on each parameter array of the PyTree.
-      Currently supports a single value (passed via l2_clip_norm), and applies
-      the same value across all leaves.
     l2_clip_norm: The maximum L2 norm for each per-example gradient. Gradients
       with a norm larger than this value will be scaled down.
+    per_layer: If True, the gradient clipping is performed on each leaf of the
+      PyTree. Rather than calculating a global L2 norm, the norm is calculated &
+      clipping threshold is applied on each parameter array of the PyTree.
+      Currently supports a single value (passed via l2_clip_norm), and applies
+      the same value across all leaves.
     rescale_to_unit_norm: If True, clipped gradients are rescaled by `1.0 /
       l2_clip_norm`. This ensures the sensitivity is 1.0. If False, they are
       only scaled down if their norm exceeds `l2_clip_norm`, resulting in a

--- a/tests/clipping_test.py
+++ b/tests/clipping_test.py
@@ -54,7 +54,10 @@ class ClipPyTreeTest(parameterized.TestCase):
     pytree = optax.tree.random_like(jax.random.key(0), pytree)
     clipped, _ = clipping.clip_pytree(pytree, **kwargs)
 
-    jitted = jax.jit(clipping.clip_pytree, static_argnums=(2, 3))
+    jitted = jax.jit(
+        clipping.clip_pytree,
+        static_argnames=('rescale_to_unit_norm', 'nan_safe'),
+    )
     clipped2, _ = jitted(pytree, **kwargs)
     chex.assert_trees_all_equal_shapes_and_dtypes(pytree, clipped, clipped2)
 
@@ -157,6 +160,39 @@ class ClipPyTreeTest(parameterized.TestCase):
     chex.assert_trees_all_close(clipped, expected)
 
     self.assertLessEqual(jnp.linalg.norm(clipped), clip_norm)
+
+  def test_clip_pytree_per_leaf_bounds(self):
+    """Tests that every individual leaf is bounded by clip_norm when per_leaf=True."""
+    # Leaf 'a' has norm 5.0, Leaf 'b' has norm 10.0
+    pytree = {'a': jnp.array([3.0, 4.0]), 'b': jnp.array([0.0, 10.0])}
+    clip_norm = 2.0
+
+    clipped, _ = clipping.clip_pytree(pytree, clip_norm, per_leaf=True)
+
+    # Each leaf is scaled down to max of clip_norm
+    for leaf in jax.tree.leaves(clipped):
+      self.assertLessEqual(jnp.linalg.norm(leaf), clip_norm + 1e-6)
+
+  def test_clip_pytree_per_leaf_reconstructed_norm_is_same_as_global_norm(self):
+    """Tests that the reconstructed global norm matches the actual global norm."""
+    # Global norm is sqrt(3^2 + 4^2 + 12^2) = sqrt(9 + 16 + 144) = 13.0
+    pytree = {'a': jnp.array([3.0, 4.0]), 'b': jnp.array([0.0, 12.0])}
+
+    _, norm_global = clipping.clip_pytree(pytree, 2.0, per_leaf=False)
+    _, norm_per_leaf = clipping.clip_pytree(pytree, 2.0, per_leaf=True)
+
+    # The reconstructed sqrt(sum(n**2)) MUST equal optax.global_norm
+    self.assertAlmostEqual(float(norm_global), float(norm_per_leaf), places=5)
+
+  def test_clip_pytree_per_leaf_single_array_equivalence(self):
+    """Tests that per_leaf and global clipping are identical for a single array."""
+    pytree = jnp.array([3.0, 4.0, 12.0])  # A PyTree with only one leaf
+    clip_norm = 5.0
+
+    clipped_global, _ = clipping.clip_pytree(pytree, clip_norm, per_leaf=False)
+    clipped_leaf, _ = clipping.clip_pytree(pytree, clip_norm, per_leaf=True)
+
+    chex.assert_trees_all_close(clipped_global, clipped_leaf)
 
 
 class ClipAndRoundToGridTest(parameterized.TestCase):


### PR DESCRIPTION
Per-layer, translates to per-leaf in the PyTree based implementation. Currently, only a singular value of max L2 Norm per leaf is supported. Upcoming change will allow the users to provide max L2-norm per leaf as a PyTree, where the L2 Norm PyTree will be a "prefix tree" of the Gradient PyTree.