### PR TITLE
Add functionality for per-layer clipping

### DIFF
--- a/jax_privacy/clipping.py
+++ b/jax_privacy/clipping.py
@@ -18,6 +18,7 @@ import collections
 from collections.abc import Sequence
 import dataclasses
 import functools
+import math
 import numbers
 from typing import Any, Callable, TypeAlias
 
@@ -28,9 +29,11 @@ import jax.numpy as jnp
 import optax
 from optax import microbatching
 
-
 PyTree: TypeAlias = chex.ArrayTree
 AuxiliaryOutput = collections.namedtuple('Aux', ['values', 'grad_norms', 'aux'])
+ClippedTreeAndNorm = collections.namedtuple(
+    '_ClippedTreeAndNorm', ['clipped', 'norm']
+)
 _REPLACE_SPECIAL = dp_accounting.NeighboringRelation.REPLACE_SPECIAL
 
 
@@ -81,15 +84,25 @@ class BoundedSensitivityCallable:
 
 def clip_pytree(
     pytree: PyTree,
-    clip_norm: float,
+    clip_norm: float | PyTree,
     rescale_to_unit_norm: bool = False,
     nan_safe: bool = True,
     return_zero: bool = False,
 ):
-  """Clips a PyTree of jax arrays based on its global L2 norm.
+  """Clips a PyTree of jax arrays.
 
-  Calculates the global L2 norm of the input PyTree. If the norm exceeds
-  `clip_norm`, the PyTree is scaled down to have norm equal to `clip_norm`.
+    The clipping behavior is determined by the type of `clip_norm`, like so:
+
+    - If `clip_norm` is a Scalar (Global Clipping): Calculates the global L2
+      norm of the input PyTree; & if the norm exceeds `clip_norm`, the entire
+      PyTree is scaled down.
+    - If `clip_norm` is a PyTree (Per-Layer Clipping): Calculates the L2 norm
+      for each individual leaf; & if a leaf's norm exceeds its corresponding
+      threshold in `clip_norm`, that specific leaf is scaled down. The
+      `clip_norm` PyTree structure must be a prefix of the input `pytree`.
+      Where `clip_norm` terminates early, its leaf values automatically
+      broadcast down to match all corresponding sub-leaves of `pytree`.
+
   If `rescale_to_unit_norm` is True, the PyTree is additionally scaled by
   `1.0 / clip_norm` (resulting in a norm of at most 1.0 no matter
   what clip_norm is). Handles cases where the original norm is zero,
@@ -117,7 +130,9 @@ def clip_pytree(
 
   Args:
     pytree: The PyTree of arrays to clip.
-    clip_norm: The maximum L2 norm allowed.
+    clip_norm: The maximum L2 norm allowed. Can be a single float or a PyTree;
+      depending on whether Global / "Per-Layer" clipping is to be done (see
+      details above).
     rescale_to_unit_norm: If True, the output PyTree's norm is rescaled by `1.0
       / clip_norm` after potential clipping. If False, the output PyTree has
       norm at most `clip_norm`.
@@ -132,7 +147,30 @@ def clip_pytree(
   Returns:
     A tuple `(clipped_pytree, original_l2_norm)`, where `clipped_pytree` is the
     processed PyTree and `original_l2_norm` is the L2 norm of the input PyTree.
+    In case of per-layer clipping the original_l2_norm is a PyTree containing
+    l2 norms of each leaf.
   """
+  # -- Per-layer Norm --
+  if not jnp.isscalar(clip_norm):
+    recursive_clip = functools.partial(
+        clip_pytree,
+        rescale_to_unit_norm=rescale_to_unit_norm,
+        nan_safe=nan_safe,
+        return_zero=return_zero,
+    )
+    results = jax.tree.map(
+        lambda c_norm, p_tree: ClippedTreeAndNorm(
+            *recursive_clip(p_tree, c_norm)
+        ),
+        clip_norm,
+        pytree,
+    )
+    is_leaf = lambda x: isinstance(x, ClippedTreeAndNorm)
+    clipped = jax.tree.map(lambda x: x.clipped, results, is_leaf=is_leaf)
+    norms = jax.tree.map(lambda x: x.norm, results, is_leaf=is_leaf)
+    return ClippedTreeAndNorm(clipped=clipped, norm=norms)
+
+  # -- Global Norm --
   if isinstance(clip_norm, numbers.Real) and clip_norm < 0:
     raise ValueError(f'clip_norm must be non-negative, got {clip_norm=}.')
 
@@ -363,7 +401,7 @@ def clipped_fun(
     *,
     batch_argnums: int | Sequence[int] = 0,
     keep_batch_dim: bool = True,
-    l2_clip_norm: float = 1.0,
+    l2_clip_norm: float | PyTree = 1.0,
     rescale_to_unit_norm: bool = False,
     normalize_by: float = 1.0,
     return_norms: bool = False,
@@ -408,7 +446,8 @@ def clipped_fun(
     keep_batch_dim: If True, batch inputs will be passed to `fun` with a leading
       batch axis of size 1.  If False, this size 1 axis will be dropped
       (reducing the rank of the batch args by 1 before passing to `fun`).
-    l2_clip_norm: The maximum L2 norm allowed.
+    l2_clip_norm: The maximum L2 norm allowed. Can be a single float or a
+      PyTree; depending on whether Global / "Per-Layer" clipping is to be done.
     rescale_to_unit_norm: If True, the output PyTree's norm is rescaled by `1.0
       / clip_norm` after potential clipping. If False, the output PyTree has
       norm at most `clip_norm`.
@@ -464,6 +503,11 @@ def clipped_fun(
       raise ValueError(
           'normalize_by is not compatible with grid_scale. Normalization '
           'should be applied after noise addition.'
+      )
+    if not jnp.isscalar(l2_clip_norm):
+      raise ValueError(
+          'Per-layer PyTree clipping is not compatible with grid scale.'
+          'l2_clip_norm must be a Real scalar.'
       )
     _check_x64_enabled()
 
@@ -548,8 +592,16 @@ def clipped_fun(
 
   if grid_scale is not None:
     norm_bound = float(grid_scale)
+  elif rescale_to_unit_norm:
+    # If every leaf is rescaled to unit norm, the worst-case global norm is
+    # the square root of the total number of leaves in the PyTree.
+    num_leaves = len(jax.tree.leaves(l2_clip_norm))
+    norm_bound = math.sqrt(num_leaves) / normalize_by
   else:
-    norm_bound = (1.0 if rescale_to_unit_norm else l2_clip_norm) / normalize_by
+    norm_bound = (
+        sum(leaf**2 for leaf in jax.tree.leaves(l2_clip_norm)) ** 0.5
+    ) / normalize_by
+
   if keep_batch_dim:
     clipped_fn = _with_extra_batch_axis(clipped_fn, batch_argnums)
   callable_has_aux = has_aux or return_norms
@@ -583,7 +635,7 @@ def clipped_grad(
     argnums: int | Sequence[int] = 0,
     has_aux: bool = False,
     *,
-    l2_clip_norm: float,
+    l2_clip_norm: float | PyTree,
     rescale_to_unit_norm: bool = False,
     normalize_by: float = 1.0,
     batch_argnums: int | Sequence[int] = 1,
@@ -643,17 +695,18 @@ def clipped_grad(
 
   Formal Guarantees:
     For the gradient output:
-      The L2 sensitivity of the returned function with respect to the batch
-      arguments (specified by `batch_argnums`) under add/remove or zero-out
-      differential privacy definitions is guaranteed to be 1.0 if
-      `rescale_to_unit_norm` is True. Otherwise, the sensitivity is
-      `l2_clip_norm`. Under replace-one DP, the sensitivity is doubled
-      (2.0 or 2 * `l2_clip_norm`).
+      The L2 sensitivity of the returned callable is a complex function of
+      the input parameters (``l2_clip_norm``, ``rescale_to_unit_norm``,
+      ``grid_scale``, per-layer clipping settings, etc.) and may change as
+      new features are added. Rather than reasoning about the sensitivity
+      from the parameters, callers should query the returned callable's
+      ``.sensitivity()`` method (or equivalently its ``.l2_norm_bound``
+      attribute for add-or-remove-one DP) directly.
     All auxiliary outputs (aux, values, grad_norms) are per-example. This
-      function guarantees that per-example outputs only depend the data for the
-      same example. This allows maximum flexibility for the caller to aggregate
-      these as desired (possibly with a DP mean, median, quantile, or histogram
-      mechanism).
+      function guarantees that per-example outputs only depend on the data for
+      the same example. This allows maximum flexibility for the caller to
+      aggregate these as desired (possibly with a DP mean, median, quantile,
+      or histogram mechanism).
 
   Args:
     fun: The function to be differentiated, which should return a scalar loss
@@ -666,7 +719,13 @@ def clipped_grad(
       Exercise caution when using this as no DP sensitivity guarantees are
       provided for the auxiliary data.
     l2_clip_norm: The maximum L2 norm for each per-example gradient. Gradients
-      with a norm larger than this value will be scaled down.
+      with a norm larger than this value will be scaled down. Can be a single
+      float or a PyTree. If Scalar: It does global clipping across all
+      gradients. If PyTree: It does per-layer clipping and contains l2 norm
+      associated with each leaf of the PyTre. The `clip_norm` PyTree structure
+      must be a prefix of the input `pytree`. Where `clip_norm` terminates
+      early, its leaf values automatically broadcast down to match all
+      corresponding sub-leaves of `pytree`.
     rescale_to_unit_norm: If True, clipped gradients are rescaled by `1.0 /
       l2_clip_norm`. This ensures the sensitivity is 1.0. If False, they are
       only scaled down if their norm exceeds `l2_clip_norm`, resulting in a
@@ -689,7 +748,11 @@ def clipped_grad(
     return_values: If True, the transformed function will also return the
       per-example values, before clipping.
     return_grad_norms: If True, the transformed function will also return the
-      per-example gradient norms, before clipping.
+      per-example gradient norms, before clipping. If `l2_clip_norm` is a
+      scalar, it returns a single global norm for the entire gradient PyTree. If
+      `l2_clip_norm` is a PyTree, it returns a matching PyTree structure where
+      each leaf contains the L2 norm of the corresponding subtree in the
+      gradient PyTree.
     pre_clipping_transform: An optional function to apply to the per-example
       gradients before clipping. The function should consume the gradient pytree
       for a single example and returned a new pytree (possibly with different
@@ -740,10 +803,13 @@ def clipped_grad(
   def grad_fn(*args, **kwargs):
     value_and_aux, grad = value_and_grad_fn(*args, **kwargs)
     result = pre_clipping_transform(grad)
+    grad_norms_val = jax.tree.map(
+        lambda _, g: optax.tree.norm(g), l2_clip_norm, grad
+    )
     if has_aux or return_values or return_grad_norms:
       aux = AuxiliaryOutput(
           values=value_and_aux[0] if return_values else None,
-          grad_norms=optax.tree.norm(grad) if return_grad_norms else None,
+          grad_norms=grad_norms_val if return_grad_norms else None,
           aux=value_and_aux[1] if has_aux else None,
       )
       return result, aux

--- a/tests/clipping_test.py
+++ b/tests/clipping_test.py
@@ -128,12 +128,19 @@ class ClipPyTreeTest(parameterized.TestCase):
       )
   )
   def test_nan_safety(self, **kwargs):
-    pytree = jnp.array([3.0, 0.0, 1.0, jnp.nan, 2.0])
-    clipped, _ = clipping.clip_pytree(pytree, nan_safe=True, **kwargs)
+    pytree_nan = {
+        'a': np.array(3.0),
+        'b': np.array(jnp.nan),
+    }
+    pytree_inf = {
+        'a': np.array(3.0),
+        'b': np.array(jnp.inf),
+    }
+
+    clipped, _ = clipping.clip_pytree(pytree_nan, nan_safe=True, **kwargs)
     chex.assert_tree_all_finite(clipped)
 
-    pytree = jnp.array([3.0, 0.0, jnp.inf, -jnp.inf, 2.0])
-    clipped, _ = clipping.clip_pytree(pytree, nan_safe=True, **kwargs)
+    clipped, _ = clipping.clip_pytree(pytree_inf, nan_safe=True, **kwargs)
     chex.assert_tree_all_finite(clipped)
 
   def test_clip_pytree_with_nan(self):
@@ -157,6 +164,103 @@ class ClipPyTreeTest(parameterized.TestCase):
     chex.assert_trees_all_close(clipped, expected)
 
     self.assertLessEqual(jnp.linalg.norm(clipped), clip_norm)
+
+  def test_clip_pytree_per_layer_full_clip_norm_tree(self):
+    """Tests per-layer clipping with complete clip_norm tree."""
+    pytree = {'a': np.array([3.0, 4.0]), 'b': np.array([0.0, 10.0])}
+    clip_norm = {'a': np.array(1.0), 'b': np.array(15.0)}
+    expected_output = {
+        # 'a' base norm is 5.0. Limit is 1.0.
+        # Scale = 1.0 / 5.0 = 0.2
+        # Scaled output = [3.0, 4.0] * 0.2 = [0.6, 0.8]
+        'a': np.array([0.6, 0.8]),
+        # 'b' base norm is 10.0. Limit is 15.0 (Unclipped).
+        # Scale = 1.0
+        # Scaled output = [0.0, 10.0] * 1.0 = [0.0, 10.0]
+        'b': np.array([0.0, 10.0]),
+    }
+    expected_norms = {
+        'a': np.array(5.0, dtype=np.float32),
+        'b': np.array(10.0, dtype=np.float32),
+    }
+    clipped_output, norms = clipping.clip_pytree(pytree, clip_norm)
+    chex.assert_trees_all_close(clipped_output, expected_output)
+    chex.assert_trees_all_close(norms, expected_norms)
+
+  def test_clip_pytree_per_layer_zero_clip_norm_tree(self):
+    """Tests per-layer clipping with zero clip_norm tree."""
+    pytree = {
+        'layer1': {'w': np.array([0.0, 0.0]), 'b': np.array([0.0])},
+    }
+    clip_norm = {'layer1': np.array(2.0)}
+    expected_output = {
+        'layer1': {
+            # 'layer1' base norm = 0.0; sqrt(0^2 + 0^2 + 0^2).
+            'w': np.array([0.0, 0.0]),
+            'b': np.array([0.0]),
+        },
+    }
+    expected_norms = {
+        'layer1': np.array(0.0, dtype=np.float32),
+    }
+    clipped_output, norms = clipping.clip_pytree(pytree, clip_norm)
+    chex.assert_trees_all_close(clipped_output, expected_output)
+    chex.assert_trees_all_close(norms, expected_norms)
+
+  def test_clip_pytree_per_layer_tuple_nodes_full_norm_tree(self):
+    """Tests per-layer clipping with pytree containing tuple leaves."""
+    pytree = {'layer1': (np.array([3.0, 4.0]), np.array([0.0, 10.0]))}
+    clip_norm = {'layer1': (np.array(1.0), np.array(15.0))}
+    expected_output = {
+        'layer1': (
+            # Element 0: base norm is 5.0. Limit is 1.0.
+            # Scale = 1.0 / 5.0 = 0.2
+            # Scaled output = [3.0, 4.0] * 0.2 = [0.6, 0.8]
+            np.array([0.6, 0.8]),
+            # Element 1: base norm is 10.0. Limit is 15.0 (Unclipped).
+            # Scale = 1.0
+            # Scaled output = [0.0, 10.0] * 1.0 = [0.0, 10.0]
+            np.array([0.0, 10.0]),
+        )
+    }
+    expected_norms = {
+        'layer1': (
+            np.array(5.0, dtype=np.float32),
+            np.array(10.0, dtype=np.float32),
+        )
+    }
+    clipped_output, norms = clipping.clip_pytree(pytree, clip_norm)
+    chex.assert_trees_all_close(clipped_output, expected_output)
+    chex.assert_trees_all_close(norms, expected_norms)
+
+  def test_clip_pytree_per_layer_prefix_clip_norm_tree(self):
+    """Tests per-layer clipping with clip_norm as prefix of pytree."""
+    pytree = {
+        'layer1': {'w': np.array([0.0, 3.0]), 'b': np.array([4.0])},
+        'layer2': {'w': np.array([0.0, 8.0]), 'b': np.array([6.0])},
+    }
+    clip_norm = {'layer1': np.array(2.0), 'layer2': np.array(5.0)}
+    expected_output = {
+        'layer1': {
+            # 'layer1' base norm = 5.0; sqrt(0^2 + 3^2 + 4^2).
+            # Limit is 2.0. Scale = 2.0 / 5.0 = 0.4
+            'w': np.array([0.0, 1.2]),
+            'b': np.array([1.6]),
+        },
+        'layer2': {
+            # 'layer2' base norm = 10.0; sqrt(0^2 + 8^2 + 6^2).
+            # Limit is 5.0. Scale = 5.0 / 10.0 = 0.5
+            'w': np.array([0.0, 4.0]),
+            'b': np.array([3.0]),
+        },
+    }
+    expected_norms = {
+        'layer1': np.array(5.0, dtype=np.float32),
+        'layer2': np.array(10.0, dtype=np.float32),
+    }
+    clipped_output, norms = clipping.clip_pytree(pytree, clip_norm)
+    chex.assert_trees_all_close(clipped_output, expected_output)
+    chex.assert_trees_all_close(norms, expected_norms)
 
 
 class ClipAndRoundToGridTest(parameterized.TestCase):
@@ -251,17 +355,23 @@ class ClippedFunGridScaleTest(parameterized.TestCase):
           enable_x64=True,
           extra_kwargs={'normalize_by': 100.0},
       ),
+      dict(
+          testcase_name='incompatible_with_pytree_clip_norm',
+          enable_x64=True,
+          extra_kwargs={'l2_clip_norm': {'a': np.array(1.0)}},
+      ),
   )
   def test_clipped_fun_grid_scale_raises(self, enable_x64, extra_kwargs):
     """Tests that clipped_fun with grid_scale raises on invalid configs."""
+    kwargs = dict(
+        fun=lambda x: x,
+        batch_argnums=0,
+        l2_clip_norm=1.0,
+        grid_scale=1000,
+    )
+    kwargs.update(extra_kwargs)
     with jax.enable_x64(enable_x64), self.assertRaises(ValueError):
-      clipping.clipped_fun(
-          lambda x: x,
-          batch_argnums=0,
-          l2_clip_norm=1.0,
-          grid_scale=1000,
-          **extra_kwargs,
-      )
+      clipping.clipped_fun(**kwargs)
 
   def test_clipped_fun_grid_scale_properties(self):
     """Tests dtype, sensitivity, and per-example norm bound with grid_scale."""
@@ -433,6 +543,84 @@ class ClipTransformTest(parameterized.TestCase):
     self.assertEqual(aux_2d.shape, (15, 4))
     self.assertEqual(aux_3d.shape, (15, 4, 9))
     self.assertEqual(aux_4d.shape, (15, 4, 9, 10))
+
+
+class ClippedFunPerLayerTest(parameterized.TestCase):
+
+  def test_clip_per_layer_clipped_fun_full_norm_tree(self):
+    """Tests clipped_fun with norm tree having same structure as pytree."""
+    pytree = {'a': np.array([3.0, 4.0]), 'b': np.array([0.0, 10.0])}
+    clip_norm = {'a': np.array(1.0), 'b': np.array(15.0)}
+    expected_output = {
+        # 'a' base norm is 5.0.
+        # Scales = 1.0/5.0 (1x), 1.0/10.0 (2x), 1.0/15.0 (3x).
+        # The scaled output is always [0.6, 0.8]. Sum: 3 * [0.6, 0.8]
+        'a': np.array([1.8, 2.4]),
+        # 'b' base norm is 10.0.
+        # Batch 1 (norm 10): Unclipped. Scale = 1.0
+        # Batch 2 (norm 20): Clipped. Scale = 15.0 / 20.0 = 0.75
+        # Batch 3 (norm 30): Clipped. Scale = 15.0 / 30.0 = 0.5
+        # Sum: ([0, 10] * 1.0) + ([0, 20] * 0.75) + ([0, 30] * 0.5)
+        'b': np.array([0.0, 40.0]),
+    }
+    expected_norms = {
+        'a': np.array([5.0, 10.0, 15.0]),
+        'b': np.array([10.0, 20.0, 30.0]),
+    }
+    cf = clipping.clipped_fun(
+        lambda x: jax.tree.map(lambda leaf: leaf * x, pytree),
+        batch_argnums=0,
+        keep_batch_dim=False,
+        l2_clip_norm=clip_norm,
+        rescale_to_unit_norm=False,
+        return_norms=True,
+    )
+    cf_output, cf_norms = cf(jnp.array([1.0, 2.0, 3.0]))
+    chex.assert_trees_all_close(cf_output, expected_output)
+    chex.assert_trees_all_close(cf_norms, expected_norms)
+
+  def test_clip_per_layer_clipped_fun_prefix_norm_tree(self):
+    """Tests clipped_fun with norm tree as prefix of pytree."""
+    pytree = {
+        'layer1': {'w': np.array([0.0, 3.0]), 'b': np.array([4.0])},
+        'layer2': {'w': np.array([0.0, 8.0]), 'b': np.array([6.0])},
+    }
+    clip_norm = {'layer1': np.array(2.0), 'layer2': np.array(5.0)}
+    expected_output = {
+        'layer1': {
+            # 'layer1' base norm = 5.0; sqrt(0^2 + 3^2 + 4^2).
+            # Batch 1 (norm 5.0): Clipped. Scale = 2.0 / 5.0
+            # Batch 2 (norm 10.0): Clipped. Scale = 2.0 / 10.0
+            # Batch 3 (norm 15.0): Clipped. Scale = 2.0 / 15.0
+            # Sum of 3 scaled batches = 3 * (2.0 / 5.0) = 1.2
+            'w': np.array([0.0, 3.0]) * 1.2,
+            'b': np.array([4.0]) * 1.2,
+        },
+        'layer2': {
+            # 'layer2' base norm = 10.0; sqrt(0^2 + 8^2 + 6^2)).
+            # Batch 1 (norm 10.0): Clipped. Scale = 5.0 / 10.0
+            # Batch 2 (norm 20.0): Clipped. Scale = 5.0 / 20.0
+            # Batch 3 (norm 30.0): Clipped. Scale = 5.0 / 30.0
+            # Sum of 3 scaled batches = 3 * (5.0 / 10.0) = 1.5
+            'w': np.array([0.0, 8.0]) * 1.5,
+            'b': np.array([6.0]) * 1.5,
+        },
+    }
+    expected_norms = {
+        'layer1': np.array([5.0, 10.0, 15.0], dtype=np.float32),
+        'layer2': np.array([10.0, 20.0, 30.0], dtype=np.float32),
+    }
+    cf = clipping.clipped_fun(
+        lambda x: jax.tree.map(lambda leaf: leaf * x, pytree),
+        batch_argnums=0,
+        keep_batch_dim=False,
+        l2_clip_norm=clip_norm,
+        rescale_to_unit_norm=False,
+        return_norms=True,
+    )
+    cf_output, cf_norms = cf(jnp.array([1.0, 2.0, 3.0]))
+    chex.assert_trees_all_close(cf_output, expected_output)
+    chex.assert_trees_all_close(cf_norms, expected_norms)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Per-layer, translates to per-leaf in the PyTree based implementation. Currently, only a singular value of max L2 Norm per leaf is supported. Upcoming change will allow the users to provide max L2-norm per leaf as a PyTree, where the L2 Norm PyTree will be a "prefix tree" of the Gradient PyTree.