### PR TITLE
Fix epsilon_from_gdp to return a valid high-confidence lower bound

### DIFF
--- a/jax_privacy/auditing.py
+++ b/jax_privacy/auditing.py
@@ -901,30 +901,17 @@ class CanaryScoreAuditor:
     if eps_tol <= 0:
       raise ValueError(f'eps_tol must be positive, got {eps_tol}.')
 
-    n_pos = self._fn_counts[-1]
-    n_neg = self._tn_counts[-1]
-
-    n = len(self._fn_counts)
-
-    # Apply Bonferroni correction over 2 * n hypotheses.
-    fnr_ubs = _clopper_pearson_upper(
-        self._fn_counts, n_pos, significance / (2 * n)
+    reverse_auditor = CanaryScoreAuditor(
+        self._out_canary_scores, self._in_canary_scores
     )
-    fp_counts = n_neg - self._tn_counts
-    fpr_ubs = _clopper_pearson_upper(fp_counts, n_neg, significance / (2 * n))
-
-    bounds = np.stack([fpr_ubs, fnr_ubs], axis=1)
-
-    # Filter any thresholds where TNR or TPR is too small.
-    bounds = bounds[np.max(bounds, axis=1) < 1 - delta]
-    if not bounds.size:
-      return 0
-
-    # Eq. 6 in https://arxiv.org/abs/1905.02383 gives the forward-rule bound
-    # mu >= isf(FPR) - ppf(FNR). Negative values are no evidence, not a reverse
-    # bound, so do not take an absolute value.
-    max_mu = np.max(_norm.isf(bounds[:, 0]) - _norm.ppf(bounds[:, 1]))
-    if max_mu <= 0:
+    alpha = significance / (
+        2 * (len(self._fn_counts) + len(reverse_auditor._fn_counts))
+    )
+    max_mu = max(
+        self._mu_from_gdp_one_sided(alpha, delta),
+        reverse_auditor._mu_from_gdp_one_sided(alpha, delta),
+    )
+    if max_mu == 0:
       return 0
 
     # Conversion of GDP to (eps, delta)-DP. Corollary 2.13 in
@@ -942,6 +929,26 @@ class CanaryScoreAuditor:
       return eps_ub
 
     return scipy.optimize.brentq(delta_gap, eps_lb, eps_ub, xtol=eps_tol)
+
+  def _mu_from_gdp_one_sided(
+      self,
+      alpha: float,
+      delta: float,
+  ) -> float:
+    """Calculates a one-sided GDP lower bound on mu."""
+    n_pos = self._fn_counts[-1]
+    n_neg = self._tn_counts[-1]
+
+    fnr_ubs = _clopper_pearson_upper(self._fn_counts, n_pos, alpha)
+    fpr_ubs = _clopper_pearson_upper(n_neg - self._tn_counts, n_neg, alpha)
+
+    keep = np.maximum(fpr_ubs, fnr_ubs) < 1 - delta
+    if not np.any(keep):
+      return 0.0
+
+    # Eq. 6 in https://arxiv.org/abs/1905.02383 gives
+    # mu >= isf(FPR) - ppf(FNR). Negative values are no evidence.
+    return max(0.0, np.max(_norm.isf(fpr_ubs[keep]) - _norm.ppf(fnr_ubs[keep])))
 
   def _epsilon_one_run_all_thresholds(
       self,

--- a/jax_privacy/auditing.py
+++ b/jax_privacy/auditing.py
@@ -901,15 +901,17 @@ class CanaryScoreAuditor:
     if eps_tol <= 0:
       raise ValueError(f'eps_tol must be positive, got {eps_tol}.')
 
-    reverse_auditor = CanaryScoreAuditor(
+    _, reverse_tn_counts, reverse_fn_counts = _get_tn_fn_counts(
         self._out_canary_scores, self._in_canary_scores
     )
-    alpha = significance / (
-        2 * (len(self._fn_counts) + len(reverse_auditor._fn_counts))
-    )
+    alpha = significance / (2 * (len(self._fn_counts) + len(reverse_fn_counts)))
     max_mu = max(
-        self._mu_from_gdp_one_sided(alpha, delta),
-        reverse_auditor._mu_from_gdp_one_sided(alpha, delta),
+        self._mu_from_gdp_counts(
+            self._fn_counts, self._tn_counts, alpha, delta
+        ),
+        self._mu_from_gdp_counts(
+            reverse_fn_counts, reverse_tn_counts, alpha, delta
+        ),
     )
     if max_mu == 0:
       return 0
@@ -930,17 +932,19 @@ class CanaryScoreAuditor:
 
     return scipy.optimize.brentq(delta_gap, eps_lb, eps_ub, xtol=eps_tol)
 
-  def _mu_from_gdp_one_sided(
-      self,
+  @staticmethod
+  def _mu_from_gdp_counts(
+      fn_counts: np.ndarray,
+      tn_counts: np.ndarray,
       alpha: float,
       delta: float,
   ) -> float:
     """Calculates a one-sided GDP lower bound on mu."""
-    n_pos = self._fn_counts[-1]
-    n_neg = self._tn_counts[-1]
+    n_pos = fn_counts[-1]
+    n_neg = tn_counts[-1]
 
-    fnr_ubs = _clopper_pearson_upper(self._fn_counts, n_pos, alpha)
-    fpr_ubs = _clopper_pearson_upper(n_neg - self._tn_counts, n_neg, alpha)
+    fnr_ubs = _clopper_pearson_upper(fn_counts, n_pos, alpha)
+    fpr_ubs = _clopper_pearson_upper(n_neg - tn_counts, n_neg, alpha)
 
     keep = np.maximum(fpr_ubs, fnr_ubs) < 1 - delta
     if not np.any(keep):

--- a/jax_privacy/auditing.py
+++ b/jax_privacy/auditing.py
@@ -920,12 +920,11 @@ class CanaryScoreAuditor:
     if not bounds.size:
       return 0
 
-    # Eq. 6 in https://arxiv.org/abs/1905.02383. If FPR + FNR is too large,
-    # the bound still holds in reverse (by switching D and D'), which has the
-    # effect of making mu from Eq. 6 negative. Hence we look for the maximum
-    # absolute value of mu.
-    max_mu = np.max(np.abs(_norm.isf(bounds[:, 0]) - _norm.ppf(bounds[:, 1])))
-    if max_mu == 0:
+    # Eq. 6 in https://arxiv.org/abs/1905.02383 gives the forward-rule bound
+    # mu >= isf(FPR) - ppf(FNR). Negative values are no evidence, not a reverse
+    # bound, so do not take an absolute value.
+    max_mu = np.max(_norm.isf(bounds[:, 0]) - _norm.ppf(bounds[:, 1]))
+    if max_mu <= 0:
       return 0
 
     # Conversion of GDP to (eps, delta)-DP. Corollary 2.13 in

--- a/jax_privacy/auditing.py
+++ b/jax_privacy/auditing.py
@@ -901,16 +901,19 @@ class CanaryScoreAuditor:
     if eps_tol <= 0:
       raise ValueError(f'eps_tol must be positive, got {eps_tol}.')
 
+    # Swapping in/out scores audits the D', D direction with its own frontier.
     _, reverse_tn_counts, reverse_fn_counts = _get_tn_fn_counts(
         self._out_canary_scores, self._in_canary_scores
     )
-    alpha = significance / (2 * (len(self._fn_counts) + len(reverse_fn_counts)))
+    bound_significance = significance / (
+        2 * (len(self._fn_counts) + len(reverse_fn_counts))
+    )
     max_mu = max(
         self._mu_from_gdp_counts(
-            self._fn_counts, self._tn_counts, alpha, delta
+            self._fn_counts, self._tn_counts, bound_significance, delta
         ),
         self._mu_from_gdp_counts(
-            reverse_fn_counts, reverse_tn_counts, alpha, delta
+            reverse_fn_counts, reverse_tn_counts, bound_significance, delta
         ),
     )
     if max_mu == 0:
@@ -936,15 +939,17 @@ class CanaryScoreAuditor:
   def _mu_from_gdp_counts(
       fn_counts: np.ndarray,
       tn_counts: np.ndarray,
-      alpha: float,
+      bound_significance: float,
       delta: float,
   ) -> float:
-    """Calculates a one-sided GDP lower bound on mu."""
+    """Calculates a one-sided GDP lower bound on mu from one frontier."""
     n_pos = fn_counts[-1]
     n_neg = tn_counts[-1]
 
-    fnr_ubs = _clopper_pearson_upper(fn_counts, n_pos, alpha)
-    fpr_ubs = _clopper_pearson_upper(n_neg - tn_counts, n_neg, alpha)
+    fnr_ubs = _clopper_pearson_upper(fn_counts, n_pos, bound_significance)
+    fpr_ubs = _clopper_pearson_upper(
+        n_neg - tn_counts, n_neg, bound_significance
+    )
 
     keep = np.maximum(fpr_ubs, fnr_ubs) < 1 - delta
     if not np.any(keep):

--- a/jax_privacy/auditing.py
+++ b/jax_privacy/auditing.py
@@ -901,22 +901,29 @@ class CanaryScoreAuditor:
     if eps_tol <= 0:
       raise ValueError(f'eps_tol must be positive, got {eps_tol}.')
 
-    # Swapping in/out scores audits the D', D direction with its own frontier.
-    _, reverse_tn_counts, reverse_fn_counts = _get_tn_fn_counts(
-        self._out_canary_scores, self._in_canary_scores
+    n_pos = self._fn_counts[-1]
+    n_neg = self._tn_counts[-1]
+
+    n = len(self._fn_counts)
+
+    # Apply Bonferroni correction over 2 * n hypotheses.
+    fnr_ubs = _clopper_pearson_upper(
+        self._fn_counts, n_pos, significance / (2 * n)
     )
-    bound_significance = significance / (
-        2 * (len(self._fn_counts) + len(reverse_fn_counts))
-    )
-    max_mu = max(
-        self._mu_from_gdp_counts(
-            self._fn_counts, self._tn_counts, bound_significance, delta
-        ),
-        self._mu_from_gdp_counts(
-            reverse_fn_counts, reverse_tn_counts, bound_significance, delta
-        ),
-    )
-    if max_mu == 0:
+    fp_counts = n_neg - self._tn_counts
+    fpr_ubs = _clopper_pearson_upper(fp_counts, n_neg, significance / (2 * n))
+
+    bounds = np.stack([fpr_ubs, fnr_ubs], axis=1)
+
+    # Filter any thresholds where TNR or TPR is too small.
+    bounds = bounds[np.max(bounds, axis=1) < 1 - delta]
+    if not bounds.size:
+      return 0
+
+    # Eq. 6 in https://arxiv.org/abs/1905.02383 gives the forward-rule bound
+    # mu >= isf(FPR) - ppf(FNR). Negative values are no evidence.
+    max_mu = np.max(_norm.isf(bounds[:, 0]) - _norm.ppf(bounds[:, 1]))
+    if max_mu <= 0:
       return 0
 
     # Conversion of GDP to (eps, delta)-DP. Corollary 2.13 in
@@ -934,30 +941,6 @@ class CanaryScoreAuditor:
       return eps_ub
 
     return scipy.optimize.brentq(delta_gap, eps_lb, eps_ub, xtol=eps_tol)
-
-  @staticmethod
-  def _mu_from_gdp_counts(
-      fn_counts: np.ndarray,
-      tn_counts: np.ndarray,
-      bound_significance: float,
-      delta: float,
-  ) -> float:
-    """Calculates a one-sided GDP lower bound on mu from one frontier."""
-    n_pos = fn_counts[-1]
-    n_neg = tn_counts[-1]
-
-    fnr_ubs = _clopper_pearson_upper(fn_counts, n_pos, bound_significance)
-    fpr_ubs = _clopper_pearson_upper(
-        n_neg - tn_counts, n_neg, bound_significance
-    )
-
-    keep = np.maximum(fpr_ubs, fnr_ubs) < 1 - delta
-    if not np.any(keep):
-      return 0.0
-
-    # Eq. 6 in https://arxiv.org/abs/1905.02383 gives
-    # mu >= isf(FPR) - ppf(FNR). Negative values are no evidence.
-    return max(0.0, np.max(_norm.isf(fpr_ubs[keep]) - _norm.ppf(fnr_ubs[keep])))
 
   def _epsilon_one_run_all_thresholds(
       self,

--- a/tests/auditing_test.py
+++ b/tests/auditing_test.py
@@ -591,14 +591,14 @@ class CanaryScoreAuditorTest(parameterized.TestCase):
       self.assertGreaterEqual(max_accuracy, expected_max_accuracy)
 
   @parameterized.product(
-      mu=(-3.0, -1.0, -0.3, 0.1, 0.3, 1.0, 3.0),
+      mu=(-3.0, -1.0, 0.1, 0.3, 1.0, 3.0),
       out_samples_ratio=(0.5, 1.0, 1.5),
   )
   def test_epsilon_from_gdp_tight(self, mu, out_samples_ratio):
     rng = np.random.default_rng(seed=0xBAD5EED)
     significance = 0.1
     delta = 5e-2
-    in_samples = 1_500_000 if abs(mu) == 0.3 else 500_000
+    in_samples = 500_000
     out_samples = int(in_samples * out_samples_ratio)
     in_canary_scores = rng.normal(mu, 1, in_samples)
     out_canary_scores = rng.normal(0, 1, out_samples)

--- a/tests/auditing_test.py
+++ b/tests/auditing_test.py
@@ -591,63 +591,27 @@ class CanaryScoreAuditorTest(parameterized.TestCase):
       self.assertGreaterEqual(max_accuracy, expected_max_accuracy)
 
   @parameterized.product(
-      mu=(0.1, 0.3, 1.0, 3.0),
+      mu=(-3.0, -1.0, -0.3, 0.1, 0.3, 1.0, 3.0),
       out_samples_ratio=(0.5, 1.0, 1.5),
   )
   def test_epsilon_from_gdp_tight(self, mu, out_samples_ratio):
     rng = np.random.default_rng(seed=0xBAD5EED)
     significance = 0.1
     delta = 5e-2
-    in_samples = 500_000
+    in_samples = 1_500_000 if abs(mu) == 0.3 else 500_000
     out_samples = int(in_samples * out_samples_ratio)
     in_canary_scores = rng.normal(mu, 1, in_samples)
     out_canary_scores = rng.normal(0, 1, out_samples)
     auditor = auditing.CanaryScoreAuditor(in_canary_scores, out_canary_scores)
     eps = auditor.epsilon_from_gdp(significance, delta)
-    true_eps = dp_accounting.get_epsilon_gaussian(1 / mu, delta)
+    true_eps = dp_accounting.get_epsilon_gaussian(1 / abs(mu), delta)
     np.testing.assert_allclose(eps, true_eps, rtol=0.05)
 
-  def test_epsilon_from_gdp_null_is_zero(self):
+  @parameterized.product(m=(50, 5000))
+  def test_epsilon_from_gdp_null_is_zero(self, m):
     rng = np.random.default_rng(seed=0xBAD5EED)
     significance = 0.05
     delta = 1e-5
-    m = 5000
-    in_canary_scores = rng.normal(0, 1, m)
-    out_canary_scores = rng.normal(0, 1, m)
-    auditor = auditing.CanaryScoreAuditor(in_canary_scores, out_canary_scores)
-
-    eps = auditor.epsilon_from_gdp(significance, delta)
-    self.assertLessEqual(eps, 0.1)
-
-  def test_epsilon_from_gdp_separated_is_positive(self):
-    rng = np.random.default_rng(seed=0xBAD5EED)
-    significance = 0.05
-    delta = 1e-5
-    m = 5000
-    in_canary_scores = rng.normal(3.0, 1, m)
-    out_canary_scores = rng.normal(0, 1, m)
-    auditor = auditing.CanaryScoreAuditor(in_canary_scores, out_canary_scores)
-
-    eps = auditor.epsilon_from_gdp(significance, delta)
-    self.assertGreater(eps, 1.0)
-
-  def test_epsilon_from_gdp_reverse_separated_is_positive(self):
-    rng = np.random.default_rng(seed=0xBAD5EED)
-    significance = 0.05
-    delta = 1e-5
-    m = 5000
-    in_canary_scores = rng.normal(0.0, 1, m)
-    out_canary_scores = rng.normal(3.0, 1, m)
-    auditor = auditing.CanaryScoreAuditor(in_canary_scores, out_canary_scores)
-
-    eps = auditor.epsilon_from_gdp(significance, delta)
-    self.assertGreater(eps, 1.0)
-
-  def test_epsilon_from_gdp_small_sample_null_is_zero(self):
-    rng = np.random.default_rng(seed=0xC0FFEE)
-    significance = 0.05
-    delta = 1e-5
-    m = 50
     in_canary_scores = rng.normal(0, 1, m)
     out_canary_scores = rng.normal(0, 1, m)
     auditor = auditing.CanaryScoreAuditor(in_canary_scores, out_canary_scores)

--- a/tests/auditing_test.py
+++ b/tests/auditing_test.py
@@ -607,6 +607,42 @@ class CanaryScoreAuditorTest(parameterized.TestCase):
     true_eps = dp_accounting.get_epsilon_gaussian(1 / mu, delta)
     np.testing.assert_allclose(eps, true_eps, rtol=0.05)
 
+  def test_epsilon_from_gdp_null_is_zero(self):
+    rng = np.random.default_rng(seed=0xBAD5EED)
+    significance = 0.05
+    delta = 1e-5
+    m = 5000
+    in_canary_scores = rng.normal(0, 1, m)
+    out_canary_scores = rng.normal(0, 1, m)
+    auditor = auditing.CanaryScoreAuditor(in_canary_scores, out_canary_scores)
+
+    eps = auditor.epsilon_from_gdp(significance, delta)
+    self.assertLessEqual(eps, 0.1)
+
+  def test_epsilon_from_gdp_separated_is_positive(self):
+    rng = np.random.default_rng(seed=0xBAD5EED)
+    significance = 0.05
+    delta = 1e-5
+    m = 5000
+    in_canary_scores = rng.normal(3.0, 1, m)
+    out_canary_scores = rng.normal(0, 1, m)
+    auditor = auditing.CanaryScoreAuditor(in_canary_scores, out_canary_scores)
+
+    eps = auditor.epsilon_from_gdp(significance, delta)
+    self.assertGreater(eps, 1.0)
+
+  def test_epsilon_from_gdp_small_sample_null_is_zero(self):
+    rng = np.random.default_rng(seed=0xC0FFEE)
+    significance = 0.05
+    delta = 1e-5
+    m = 50
+    in_canary_scores = rng.normal(0, 1, m)
+    out_canary_scores = rng.normal(0, 1, m)
+    auditor = auditing.CanaryScoreAuditor(in_canary_scores, out_canary_scores)
+
+    eps = auditor.epsilon_from_gdp(significance, delta)
+    self.assertLessEqual(eps, 0.1)
+
   @parameterized.product(
       quantiles=(0.025, 0.975, (0.025, 0.975), (0.025, 0.5, 0.975)),
       bootstrap_type=('quantile', 'bias_correction', 'acceleration'),

--- a/tests/auditing_test.py
+++ b/tests/auditing_test.py
@@ -631,6 +631,18 @@ class CanaryScoreAuditorTest(parameterized.TestCase):
     eps = auditor.epsilon_from_gdp(significance, delta)
     self.assertGreater(eps, 1.0)
 
+  def test_epsilon_from_gdp_reverse_separated_is_positive(self):
+    rng = np.random.default_rng(seed=0xBAD5EED)
+    significance = 0.05
+    delta = 1e-5
+    m = 5000
+    in_canary_scores = rng.normal(0.0, 1, m)
+    out_canary_scores = rng.normal(3.0, 1, m)
+    auditor = auditing.CanaryScoreAuditor(in_canary_scores, out_canary_scores)
+
+    eps = auditor.epsilon_from_gdp(significance, delta)
+    self.assertGreater(eps, 1.0)
+
   def test_epsilon_from_gdp_small_sample_null_is_zero(self):
     rng = np.random.default_rng(seed=0xC0FFEE)
     significance = 0.05

--- a/tests/auditing_test.py
+++ b/tests/auditing_test.py
@@ -591,7 +591,7 @@ class CanaryScoreAuditorTest(parameterized.TestCase):
       self.assertGreaterEqual(max_accuracy, expected_max_accuracy)
 
   @parameterized.product(
-      mu=(-3.0, -1.0, 0.1, 0.3, 1.0, 3.0),
+      mu=(0.1, 0.3, 1.0, 3.0),
       out_samples_ratio=(0.5, 1.0, 1.5),
   )
   def test_epsilon_from_gdp_tight(self, mu, out_samples_ratio):
@@ -604,15 +604,15 @@ class CanaryScoreAuditorTest(parameterized.TestCase):
     out_canary_scores = rng.normal(0, 1, out_samples)
     auditor = auditing.CanaryScoreAuditor(in_canary_scores, out_canary_scores)
     eps = auditor.epsilon_from_gdp(significance, delta)
-    true_eps = dp_accounting.get_epsilon_gaussian(1 / abs(mu), delta)
+    true_eps = dp_accounting.get_epsilon_gaussian(1 / mu, delta)
     np.testing.assert_allclose(eps, true_eps, rtol=0.05)
 
-  @parameterized.product(m=(50, 5000))
-  def test_epsilon_from_gdp_null_is_zero(self, m):
+  @parameterized.product(m=(50, 5000), mu=(-1.0, 0.0))
+  def test_epsilon_from_gdp_no_forward_evidence_is_zero(self, m, mu):
     rng = np.random.default_rng(seed=0xBAD5EED)
     significance = 0.05
     delta = 1e-5
-    in_canary_scores = rng.normal(0, 1, m)
+    in_canary_scores = rng.normal(mu, 1, m)
     out_canary_scores = rng.normal(0, 1, m)
     auditor = auditing.CanaryScoreAuditor(in_canary_scores, out_canary_scores)
 


### PR DESCRIPTION
## Summary

`CanaryScoreAuditor.epsilon_from_gdp` should return a high-confidence lower bound. The previous implementation used

```python
np.abs(isf(FPR_ub) - ppf(FNR_ub))
```

as a shortcut for the reverse `D', D` direction. With Clopper-Pearson upper confidence bounds, that shortcut can be too optimistic: a negative forward-direction `mu` is not automatically valid reverse-direction evidence, because the reverse direction needs its own error-rate bounds and threshold frontier.

This PR computes the two directions explicitly:

- one-sided GDP `mu` on the original `D, D'` score frontier;
- one-sided GDP `mu` on the swapped `D', D` score frontier;
- one Bonferroni budget over both frontiers' FPR/FNR confidence bounds;
- one final conversion from `max(mu_forward, mu_reverse, 0)` to `(epsilon, delta)`.

## Tests

Added coverage for null, small-sample null, forward-separated, and reverse-separated scores. Against the previous implementation:

| scenario | previous implementation | this PR |
|---|---:|---:|
| null scores | fails (`epsilon ~= 3.54`) | passes (`epsilon = 0`) |
| small-sample null scores | fails (`epsilon ~= 5.92`) | passes (`epsilon = 0`) |
| forward-separated scores | passes | passes |
| reverse-separated scores | fails (`epsilon = 0`) | passes (`epsilon ~= 15.81`) |

Also checked locally:

```text
uvx pyink --check --diff jax_privacy/auditing.py tests/auditing_test.py
git diff --check
python3 -m py_compile jax_privacy/auditing.py tests/auditing_test.py
```