### PR TITLE
Validate explicit noise_multiplier at the effective batch size

### DIFF
--- a/jax_privacy/keras_api.py
+++ b/jax_privacy/keras_api.py
@@ -227,7 +227,7 @@ class DPKerasConfig:
     if self.noise_multiplier is not None:
       _validate.positive(noise_multiplier=self.noise_multiplier)
       try:
-        sampling_prob = self.batch_size / self.train_size
+        sampling_prob = self.effective_batch_size / self.train_size
         event = accounting.dpsgd_event(
             noise_multiplier=self.noise_multiplier,
             iterations=self.train_steps,

--- a/tests/keras_api_test.py
+++ b/tests/keras_api_test.py
@@ -120,6 +120,22 @@ class KerasApiTest(parameterized.TestCase):
     ):
       dataclasses.replace(valid_params, microbatch_size=11)
 
+  def test_validate_noise_multiplier_uses_effective_batch_size(self):
+    # Validation must account at the same sampling rate as
+    # update_with_calibrated_noise_multiplier, i.e. effective_batch_size =
+    # batch_size * gradient_accumulation_steps; the old code dropped the
+    # gradient_accumulation_steps factor. With gas > 1 that under-accounts:
+    # noise_multiplier=1.0 gives epsilon ~0.72 at the physical batch size (which
+    # the old check wrongly accepted against the target epsilon of 1.1) but ~5.6
+    # at the effective batch size, so it must be rejected.
+    params = dataclasses.replace(
+        self._get_params(), gradient_accumulation_steps=8
+    )
+    with self.assertRaisesRegex(
+        ValueError, "will lead to privacy budget exceed"
+    ):
+      dataclasses.replace(params, noise_multiplier=1.0)
+
   def test_poisson_sampling_in_fit_defaults_to_disabled(self):
     self.assertFalse(self._get_params().poisson_sampling_in_fit)
 


### PR DESCRIPTION
## Summary

`update_with_calibrated_noise_multiplier` and `_validate_params` must account at the **same** sampling rate, but the validation path's `sampling_prob` dropped the `gradient_accumulation_steps` factor that calibration includes:

- calibration: `sampling_prob = effective_batch_size / train_size` (= `batch_size * gradient_accumulation_steps / train_size`)
- validation (before): `sampling_prob = batch_size / train_size`

With `gradient_accumulation_steps > 1` the validation under-accounts (smaller sampling rate → smaller epsilon) and can accept a user-supplied `noise_multiplier` that actually exceeds the privacy budget.

## Fix

One line: make validation use `effective_batch_size / train_size`, identical to the calibration path (same `sampling_prob`, same `iterations=train_steps`). This is privacy-conservative — it can only ever reject more — and a no-op when `gradient_accumulation_steps == 1`.

## Test

`test_validate_noise_multiplier_uses_effective_batch_size`: with `gradient_accumulation_steps=8` (batch_size=10, train_steps=100, train_size=1000, target epsilon=1.1, delta=1e-5), `noise_multiplier=1.0` gives epsilon ≈ 0.72 at the physical batch size (which the old check wrongly accepted) but ≈ 5.6 at the effective batch size, so it must be rejected. Fails on the old code (no raise), passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
