### PR TITLE
Warn when accounting assumes Poisson but poisson_sampling_in_fit=False

### DIFF
--- a/jax_privacy/keras_api.py
+++ b/jax_privacy/keras_api.py
@@ -48,6 +48,7 @@ import inspect
 import math
 import types
 from typing import Any
+import warnings
 
 import chex
 import dp_accounting
@@ -201,6 +202,25 @@ class DPKerasConfig:
 
   def _validate_params(self) -> None:
     """Validates the parameters for DP-SGD training."""
+    if not self.poisson_sampling_in_fit:
+      # The privacy accountant (update_with_calibrated_noise_multiplier and the
+      # epsilon check below) always models DP-SGD as Poisson subsampling
+      # amplification via accounting.dpsgd_event. When
+      # poisson_sampling_in_fit=False, the wrapped fit() consumes the user's
+      # own pre-batched (typically shuffled, fixed-size) data, which does NOT
+      # satisfy Poisson subsampling, so the reported (epsilon, delta) assumes
+      # amplification the default data path does not provide.
+      warnings.warn(
+          'The reported (epsilon, delta) privacy guarantee assumes Poisson'
+          ' subsampling amplification, but poisson_sampling_in_fit=False. The'
+          ' default fit() path consumes your pre-batched (typically shuffled,'
+          ' fixed-size) data and does NOT perform Poisson sampling, so the'
+          ' computed epsilon may understate the true privacy loss. Either set'
+          ' poisson_sampling_in_fit=True, or ensure your input pipeline'
+          ' performs Poisson subsampling before passing data to fit().',
+          UserWarning,
+          stacklevel=2,
+      )
     _validate.positive(
         epsilon=self.epsilon,
         delta=self.delta,

--- a/tests/keras_api_test.py
+++ b/tests/keras_api_test.py
@@ -16,6 +16,7 @@ import dataclasses
 import os
 import types
 from unittest import mock
+import warnings
 
 os.environ["KERAS_BACKEND"] = "jax"
 # pylint: disable=g-import-not-at-top, wrong-import-position
@@ -122,6 +123,42 @@ class KerasApiTest(parameterized.TestCase):
 
   def test_poisson_sampling_in_fit_defaults_to_disabled(self):
     self.assertFalse(self._get_params().poisson_sampling_in_fit)
+
+  def test_warns_when_poisson_sampling_in_fit_disabled(self):
+    # The accountant always assumes Poisson subsampling amplification, but the
+    # default fit() path (poisson_sampling_in_fit=False) does not perform it.
+    # Constructing such a config must emit an actionable UserWarning so the
+    # reported epsilon is not silently trusted.
+    with self.assertWarnsRegex(
+        UserWarning,
+        "assumes Poisson subsampling amplification",
+    ):
+      keras_api.DPKerasConfig(
+          epsilon=1.1,
+          delta=1e-5,
+          clipping_norm=1.0,
+          batch_size=10,
+          gradient_accumulation_steps=1,
+          train_steps=100,
+          train_size=1000,
+          poisson_sampling_in_fit=False,
+      )
+
+  def test_no_warning_when_poisson_sampling_in_fit_enabled(self):
+    # When Poisson sampling is performed in fit(), the amplified accounting is
+    # justified and no warning should be emitted.
+    with warnings.catch_warnings():
+      warnings.simplefilter("error", UserWarning)
+      keras_api.DPKerasConfig(
+          epsilon=1.1,
+          delta=1e-5,
+          clipping_norm=1.0,
+          batch_size=10,
+          gradient_accumulation_steps=1,
+          train_steps=100,
+          train_size=1000,
+          poisson_sampling_in_fit=True,
+      )
 
   def test_effective_batch_size(self):
     params1 = dataclasses.replace(self._get_params(), batch_size=5)


### PR DESCRIPTION
## Summary
The Keras DP-SGD accountant always assumes Poisson subsampling amplification, but `poisson_sampling_in_fit` defaults to `False`. In that default configuration the reported `(epsilon, delta)` silently assumes amplification the data path does not provide. This PR adds a warning (no numeric change).

## The issue
`accounting.dpsgd_event` (used by both `update_with_calibrated_noise_multiplier` and the `_validate_params` epsilon check) always wraps the Gaussian in a `PoissonSampledDpEvent`. But with `poisson_sampling_in_fit=False` (the default), the wrapped `fit()` consumes the user's own pre-batched data — typically shuffled, fixed-size minibatches — which does **not** satisfy Poisson subsampling. The amplified epsilon is then reported with no indication that the guarantee depends on a sampling scheme the default pipeline doesn't implement.

## The change
Emit a `UserWarning` from `DPKerasConfig` when `poisson_sampling_in_fit=False`, telling the user to either set it to `True` or ensure their input pipeline performs Poisson subsampling. No accounting/noise/sensitivity behavior changes.

```
The reported (epsilon, delta) privacy guarantee assumes Poisson subsampling
amplification, but poisson_sampling_in_fit=False. The default fit() path
consumes your pre-batched (typically shuffled, fixed-size) data and does NOT
perform Poisson sampling, so the computed epsilon may understate the true
privacy loss. Either set poisson_sampling_in_fit=True, or ensure your input
pipeline performs Poisson subsampling before passing data to fit().
```

## Notes / open questions
- This is intentionally the minimal, conservative change (a warning). A deeper fix would be to account with a non-amplified event when `poisson_sampling_in_fit=False` — happy to take direction on whether you'd prefer that.
- Placement is in `_validate_params` so it fires on config construction. It currently warns on every default config; if you'd rather it fire once at calibration/`fit` time, easy to move.

## Verification
- New `test_warns_when_poisson_sampling_in_fit_disabled` and `test_no_warning_when_poisson_sampling_in_fit_enabled`.
- Full `keras_api_test.py` (37 tests) passes (no `filterwarnings=error` in the project config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
