### PR TITLE
Validate structural arguments (num_bands, truncated sizes) in accounting events

### DIFF
--- a/jax_privacy/accounting.py
+++ b/jax_privacy/accounting.py
@@ -225,6 +225,9 @@ def truncated_dpsgd_event(
     A DpEvent object.
   """
   _validate_poisson_args(noise_multiplier, iterations, sampling_prob)
+  _validate.non_negative(
+      num_examples=num_examples, truncated_batch_size=truncated_batch_size
+  )
   sampled_gaussian = dp_accounting.TruncatedSubsampledGaussianDpEvent(
       dataset_size=num_examples,
       sampling_probability=sampling_prob,
@@ -264,6 +267,7 @@ def amplified_bandmf_event(
     A DpEvent object.
   """
   _validate_poisson_args(noise_multiplier, iterations, sampling_prob)
+  _validate.positive(num_bands=num_bands)
   rounds = math.ceil(iterations / num_bands)
   return dpsgd_event(
       noise_multiplier=noise_multiplier,
@@ -307,6 +311,7 @@ def truncated_amplified_bandmf_event(
     A DpEvent object.
   """
   _validate_poisson_args(noise_multiplier, iterations, sampling_prob)
+  _validate.positive(num_bands=num_bands)
   return truncated_dpsgd_event(
       noise_multiplier=noise_multiplier,
       sampling_prob=sampling_prob,

--- a/tests/accounting_test.py
+++ b/tests/accounting_test.py
@@ -233,6 +233,95 @@ class AccountingTest(parameterized.TestCase):
     # as the continuous Gaussian with the same sigma.
     self.assertAlmostEqual(eps_continuous, eps_discrete, places=4)
 
+  # -- Structural-argument validation ----------------------------------------
+  # num_bands flows into math.ceil(iterations / num_bands); the truncated sizes
+  # flow into TruncatedSubsampledGaussianDpEvent. These were previously
+  # unvalidated: num_bands=0 raised an opaque ZeroDivisionError, num_bands<0
+  # raised a misleading "iterations=..." error, and negative sizes were silently
+  # accepted and produced a nonsensical event.
+
+  @parameterized.parameters(0, -1, -16)
+  def test_amplified_bandmf_event_rejects_nonpositive_num_bands(
+      self, num_bands
+  ):
+    with self.assertRaisesRegex(ValueError, rf"num_bands={num_bands} > 0"):
+      accounting.amplified_bandmf_event(
+          1.0, 128, num_bands=num_bands, sampling_prob=0.01
+      )
+
+  @parameterized.parameters(0, -1, -16)
+  def test_truncated_amplified_bandmf_rejects_nonpositive_num_bands(
+      self, num_bands
+  ):
+    with self.assertRaisesRegex(ValueError, rf"num_bands={num_bands} > 0"):
+      accounting.truncated_amplified_bandmf_event(
+          1.0,
+          128,
+          num_bands=num_bands,
+          sampling_prob=0.01,
+          largest_group_size=1000,
+          truncated_batch_size=16,
+      )
+
+  @parameterized.parameters(
+      dict(num_examples=-1, truncated_batch_size=16),
+      dict(num_examples=1000, truncated_batch_size=-1),
+      dict(num_examples=-5, truncated_batch_size=-3),
+  )
+  def test_truncated_dpsgd_event_rejects_negative_sizes(
+      self, num_examples, truncated_batch_size
+  ):
+    with self.assertRaisesRegex(ValueError, r">= 0"):
+      accounting.truncated_dpsgd_event(
+          1.0,
+          10,
+          sampling_prob=0.1,
+          num_examples=num_examples,
+          truncated_batch_size=truncated_batch_size,
+      )
+
+  def test_truncated_amplified_bandmf_rejects_negative_sizes(self):
+    # largest_group_size / truncated_batch_size are forwarded to
+    # truncated_dpsgd_event and validated there.
+    with self.assertRaisesRegex(ValueError, r">= 0"):
+      accounting.truncated_amplified_bandmf_event(
+          1.0,
+          128,
+          num_bands=16,
+          sampling_prob=0.01,
+          largest_group_size=-1,
+          truncated_batch_size=16,
+      )
+
+  def test_amplified_bandmf_event_valid_num_bands_unchanged(self):
+    # Regression: positive num_bands is unaffected. The mechanism runs
+    # rounds = ceil(iterations / num_bands) DP-SGD steps.
+    event = accounting.amplified_bandmf_event(
+        1.0, 128, num_bands=16, sampling_prob=0.01
+    )
+    self.assertIsInstance(event, dp_accounting.dp_event.SelfComposedDpEvent)
+    self.assertEqual(event.count, 8)  # ceil(128 / 16)
+
+  def test_truncated_amplified_bandmf_valid_args_unchanged(self):
+    event = accounting.truncated_amplified_bandmf_event(
+        1.0,
+        128,
+        num_bands=16,
+        sampling_prob=0.01,
+        largest_group_size=1000,
+        truncated_batch_size=16,
+    )
+    self.assertIsInstance(event, dp_accounting.dp_event.SelfComposedDpEvent)
+    self.assertEqual(event.count, 8)  # ceil(128 / 16)
+
+  def test_truncated_dpsgd_event_valid_args_unchanged(self):
+    # Regression: non-negative (incl. zero) sizes still build the event.
+    event = accounting.truncated_dpsgd_event(
+        1.0, 10, sampling_prob=0.1, num_examples=1000, truncated_batch_size=16
+    )
+    self.assertIsInstance(event, dp_accounting.dp_event.SelfComposedDpEvent)
+    self.assertEqual(event.count, 10)
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
## Bug

Several `jax_privacy.accounting` event builders forward user-controlled structural arguments into divisions / sizing without validating them, so invalid inputs either crash opaquely or are silently accepted:

```python
>>> from jax_privacy import accounting
>>> accounting.amplified_bandmf_event(1.0, 128, num_bands=0, sampling_prob=0.01)
ZeroDivisionError: division by zero
>>> accounting.amplified_bandmf_event(1.0, 128, num_bands=-4, sampling_prob=0.01)
ValueError: Expected iterations=-32 >= 0.          # misleading: blames iterations
>>> accounting.truncated_dpsgd_event(1.0, 10, sampling_prob=0.1,
...     num_examples=-5, truncated_batch_size=-3)
<SelfComposedDpEvent ...>                           # silently accepted, nonsensical
```

`num_bands` flows into `math.ceil(iterations / num_bands)` in `amplified_bandmf_event` and `truncated_amplified_bandmf_event`; `num_examples` / `truncated_batch_size` flow into `TruncatedSubsampledGaussianDpEvent` in `truncated_dpsgd_event`. None were validated, while sibling builders (`fixed_dpsgd_event` via `_validate_fixed_args`) already validate their sizes.

## Fix

- `_validate.positive(num_bands=num_bands)` in both BandMF builders (must be ≥ 1 to partition the data and to divide by).
- `_validate.non_negative(num_examples=..., truncated_batch_size=...)` in `truncated_dpsgd_event`, matching the `_validate_fixed_args` convention for dataset/batch sizes.

Only previously-invalid inputs (non-positive `num_bands`, negative sizes) are rejected — valid inputs are unchanged. This mirrors the already-merged #255 and the existing `_validate` pattern.

## Testing

`python -m pytest tests/accounting_test.py` — 36 passed. The new parameterized tests cover each newly-guarded argument × invalid value, plus positive regressions; they fail (8 failures + 2 ZeroDivisionError) against the pre-fix code and pass after.
