### PR TITLE
docs: fix RST rendering of code blocks in toeplitz docstrings (#198)

### DIFF
--- a/jax_privacy/matrix_factorization/toeplitz.py
+++ b/jax_privacy/matrix_factorization/toeplitz.py
@@ -177,16 +177,14 @@ def materialize_lower_triangular(
 ) -> jax.Array:
   """Creates a lower-triangular Toeplitz matrix.
 
-   Example: If `coef = [a, b, c]` and `n = 6`, then this method returns:
+  Example: If ``coef = [a, b, c]`` and ``n = 6``, then this method returns::
 
-  ```
-  [a 0 0 0 0 0]
-  [b a 0 0 0 0]
-  [c b a 0 0 0]
-  [0 c b a 0 0]
-  [0 0 c b a 0]
-  [0 0 0 c b a]
-  ```
+    [a 0 0 0 0 0]
+    [b a 0 0 0 0]
+    [c b a 0 0 0]
+    [0 c b a 0 0]
+    [0 0 c b a 0]
+    [0 0 0 c b a]
 
   Args:
     coef: The nonzero coefficients of a lower-triangular Toeplitz matrix C, that
@@ -211,16 +209,15 @@ def solve_banded(coef: jax.Array, rhs: jax.Array) -> jax.Array:
   Note we want to be able to back-propagate gradients through this function,
   hence we cannot use scipy.linalg.solve_toeplitz.
 
-  Example: coef = [a, b, c], rhs = [1, 1, 1, 1, 1, 1], we solve the following
-  system for x
-  ```
-  [a 0 0 0 0 0] [x_0]   [1]
-  [b a 0 0 0 0] [x_1]   [1]
-  [c b a 0 0 0] [x_2] = [1]
-  [0 c b a 0 0] [x_3]   [1]
-  [0 0 c b a 0] [x_4]   [1]
-  [0 0 0 c b a] [x_5]   [1]
-  ```
+  Example: ``coef = [a, b, c]``, ``rhs = [1, 1, 1, 1, 1, 1]``, we solve the
+  following system for x::
+
+    [a 0 0 0 0 0] [x_0]   [1]
+    [b a 0 0 0 0] [x_1]   [1]
+    [c b a 0 0 0] [x_2] = [1]
+    [0 c b a 0 0] [x_3]   [1]
+    [0 0 c b a 0] [x_4]   [1]
+    [0 0 0 c b a] [x_5]   [1]
 
   Args:
     coef: The nonzero coefficients of a lower-triangular Toeplitz matrix C, that


### PR DESCRIPTION
## What

Addresses part of #198 (RTD formatting — item 1, "Code is not being formatted properly"). The `matrix_factorization.toeplitz` docstrings for `materialize_lower_triangular` and `solve_banded` wrap their example ASCII matrices in Markdown ```` ``` ```` fences. Docstrings are rendered as reStructuredText (Sphinx + napoleon), where triple backticks are not code-block syntax, so the matrices render with literal backtick characters and get reflowed instead of shown as a monospace block (visible on the [`solve_banded` RTD page](https://jax-privacy.readthedocs.io/en/latest/_autosummary_output/jax_privacy.matrix_factorization.toeplitz.solve_banded.html) cited in the issue).

## Fix

Convert the two fenced blocks to RST literal blocks (end the lead-in line with `::` and indent the matrix), and mark the inline `coef`/`n`/`rhs` examples as inline literals (``` `` ```).

## Verification

Rendered both (dedented) docstrings through `docutils`: each now produces exactly one `literal_block` node (the matrix) plus inline `literal` nodes, with no warnings introduced by the change.

Per the issue ("Incremental changes to fix these up will be good"), this is scoped to the two cited functions; happy to follow up on the other sub-items (type-alias rendering, overview links) separately.
