### PR TITLE
Add DP-SAPF saliency-aware LoRA layer selection example.

### DIFF
--- a/examples/dpsapf_validate.py
+++ b/examples/dpsapf_validate.py
@@ -1,26 +1,29 @@
 #!/usr/bin/env python3
-# Copyright 2026 The Authors.
+# Copyright 2026 DeepMind Technologies Limited.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Validate that `jax_privacy.saliency.topk_vote_probe` produces useful masks.
 
 Runs two DP-SGD fine-tunes of Gemma3 under matched (eps, delta):
 
-  (1) baseline: LoRA on every candidate attention projection (~ the
-      keras_hub `enable_lora()` default of query+value everywhere, but
-      extended to all attention leaves for a fairer 'adapt everything'
-      reference)
+  (1) baseline: the default LoRA layers selected by keras_hub's
+      `enable_lora()` policy (typically query+value projections)
   (2) DP-SAPF: LoRA on the top-`--top_k_percent`% attention layers selected
       by the DP probe
 
-Reports ROUGE-1/2/L for both and the delta. `dp_sgd_keras_gemma3_dpsapf.ipynb`
-demonstrates the full mechanism; this script exists so you can iterate on
-the probe implementation without a Jupyter round-trip.
+Reports ROUGE-1/2/L for both and the delta. This script provides an end-to-end
+validation path for iterating on the probe implementation.
 
 Typical run (single-GPU, ~10-20 min per config on 1B):
   python examples/dpsapf_validate.py \\
@@ -209,12 +212,26 @@ def parse_args():
   p.add_argument("--test_batch_size", type=int, default=4)
   p.add_argument("--lora_rank", type=int, default=64)
   p.add_argument("--learning_rate", type=float, default=3e-3)
-  p.add_argument("--seed", type=int, default=0)
+  p.add_argument(
+      "--seed",
+      type=int,
+      default=None,
+      help=(
+          "Optional reproducibility seed. Leave unset for private randomness; "
+          "a public or predictable seed invalidates the DP guarantee."
+      ),
+  )
   # Probe
-  p.add_argument("--probe_samples", type=int, default=50000)
+  p.add_argument(
+      "--probe_samples",
+      type=int,
+      default=50000,
+      help="Expected Poisson probe size (capped at the training-set size).",
+  )
   p.add_argument("--probe_topk", type=int, default=8)
   p.add_argument("--probe_noise_multiplier", type=float, default=20.0)
   p.add_argument("--probe_microbatch_size", type=int, default=4)
+  p.add_argument("--probe_preprocessing_batch_size", type=int, default=128)
   p.add_argument("--top_k_percent", type=float, default=5.0)
   # DP
   p.add_argument("--total_epsilon", type=float, default=4.0)
@@ -251,7 +268,10 @@ def main():
   import jax
   import keras
   import keras_hub  # pytype: disable=import-error
+  import numpy as np
+  import tensorflow as tf
 
+  from jax_privacy import batch_selection
   from jax_privacy import saliency
 
   print(f"Dataset: {args.dataset}   Model: {args.model}")
@@ -268,6 +288,32 @@ def main():
 
   train_size = int(train_ds.cardinality().numpy())
   print(f"train_size={train_size}")
+  if train_size <= 0:
+    raise ValueError("The training split must contain at least one record.")
+  if args.probe_samples <= 0:
+    raise ValueError("--probe_samples must be positive.")
+  if args.probe_preprocessing_batch_size <= 0:
+    raise ValueError("--probe_preprocessing_batch_size must be positive.")
+
+  expected_probe_size = min(args.probe_samples, train_size)
+  probe_sampling_probability = expected_probe_size / train_size
+  probe_sampling = batch_selection.CyclicPoissonSampling(
+      sampling_prob=probe_sampling_probability,
+      iterations=1,
+      partition_type=batch_selection.PartitionType.INDEPENDENT,
+  )
+  sampling_seed, probe_noise_seed_sequence = np.random.SeedSequence(
+      args.seed
+  ).spawn(2)
+  sampling_rng = np.random.default_rng(sampling_seed)
+  probe_indices = next(
+      probe_sampling.batch_iterator(train_size, rng=sampling_rng)
+  )
+  print(
+      "probe Poisson sampling: "
+      f"q={probe_sampling_probability:.6f}, "
+      f"expected_size={expected_probe_size}"
+  )
 
   train_ds_batched = train_ds.shuffle(2048).batch(
       args.batch_size, drop_remainder=True
@@ -315,45 +361,72 @@ def main():
 
   preproc = gemma_lm.preprocessor
 
-  def probe_batches():
-    """Yields microbatches (dict) shaped for `loss_fn`."""
-    src = (
-        train_ds_batched.unbatch()
-        .take(args.probe_samples)
-        .batch(args.probe_microbatch_size, drop_remainder=True)
-    )
-    for chunk in src:
-      x, y, sw = preproc(chunk)
-      # convert to jax arrays
-      x = {
-          k: jax.numpy.asarray(v.numpy() if hasattr(v, "numpy") else v)
-          for k, v in x.items()
-      }
-      y = jax.numpy.asarray(y.numpy() if hasattr(y, "numpy") else y)
-      sw = (
-          jax.numpy.asarray(sw.numpy() if hasattr(sw, "numpy") else sw)
-          if sw is not None
-          else jax.numpy.ones_like(y, dtype=jax.numpy.float32)
+  # Select each member of the full population independently with probability
+  # q. Keeping the same `probe_sampling` object for the probe call below ties
+  # the implemented sampling mechanism to the emitted DpEvent.
+  selection_mask = np.zeros(train_size, dtype=np.bool_)
+  selection_mask[probe_indices] = True
+  selection_mask = tf.convert_to_tensor(selection_mask)
+
+  def keep_probe_example(index, unused_example):
+    del unused_example
+    return tf.gather(selection_mask, index)
+
+  def drop_example_index(unused_index, example):
+    del unused_index
+    return example
+
+  selected_probe_ds = (
+      train_ds.enumerate().filter(keep_probe_example).map(drop_example_index)
+  )
+
+  def preprocess_probe_chunk(chunk):
+    """Preprocesses one host chunk into the batched loss-function pytree."""
+    x, y, sw = preproc(chunk)
+    y = np.asarray(y)
+    if sw is None:
+      sw = np.ones_like(y, dtype=np.float32)
+    return jax.tree.map(np.asarray, {"x": x, "y": y, "sw": sw})
+
+  probe_chunks = [
+      preprocess_probe_chunk(chunk)
+      for chunk in selected_probe_ds.batch(
+          args.probe_preprocessing_batch_size, drop_remainder=False
       )
-      yield {"x": x, "y": y, "sw": sw}
+  ]
+  if probe_chunks:
+    probe_batch = jax.tree.map(
+        lambda *chunks: np.concatenate(chunks, axis=0), *probe_chunks
+    )
+  else:
+    # A Poisson draw may be empty. Use one record only to obtain shapes; the
+    # empty batch is handled without evaluating `loss_fn` in the probe.
+    shape_chunk = next(iter(train_ds.take(1).batch(1)))
+    probe_batch = jax.tree.map(
+        lambda x: x[:0], preprocess_probe_chunk(shape_chunk)
+    )
+
+  materialized_probe_size = jax.tree.leaves(probe_batch)[0].shape[0]
+  if materialized_probe_size != len(probe_indices):
+    raise RuntimeError(
+        "Poisson sample materialization did not preserve the sampled size."
+    )
+
+  probe_noise_seed = int(probe_noise_seed_sequence.generate_state(1)[0])
 
   probe_result = saliency.topk_vote_probe(
       loss_fn=loss_fn,
-      dataset=probe_batches(),
+      dataset=probe_batch,
       params=[v.value for v in trainable_vars],
-      num_samples=args.probe_samples,
       vote_top_k=args.probe_topk,
       select_top_k=select_top_k,
       noise_multiplier=args.probe_noise_multiplier,
       candidate_mask=candidate_mask,
-      prng_key=jax.random.PRNGKey(args.seed),
-      sampling_probability=args.probe_samples / train_size,
+      prng_key=jax.random.PRNGKey(probe_noise_seed),
+      sampling_strategy=probe_sampling,
       microbatch_size=args.probe_microbatch_size,
   )
-  print(
-      f"probe: {probe_result.n_seen} samples, "
-      f"kept {select_top_k}/{num_candidates} layers."
-  )
+  print(f"probe complete: kept {select_top_k}/{num_candidates} layers.")
   # Translate the boolean pytree back to the set of `.path` strings that
   # `_enable_lora_on_paths` expects.
   probe_selected_paths = _mask_to_paths(
@@ -390,7 +463,10 @@ def main():
   trainable_vars = None
   ntvars = None
   loss_fn = None
-  probe_batches = None
+  probe_batch = None
+  probe_chunks = None
+  probe_indices = None
+  selection_mask = None
   gc.collect()
   jax.clear_caches()
 

--- a/examples/dpsapf_validate.py
+++ b/examples/dpsapf_validate.py
@@ -1,0 +1,583 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Validate that `jax_privacy.saliency.topk_vote_probe` produces useful masks.
+
+Runs two DP-SGD fine-tunes of Gemma3 under matched (eps, delta):
+
+  (1) baseline: LoRA on every candidate attention projection (~ the
+      keras_hub `enable_lora()` default of query+value everywhere, but
+      extended to all attention leaves for a fairer 'adapt everything'
+      reference)
+  (2) DP-SAPF: LoRA on the top-`--top_k_percent`% attention layers selected
+      by the DP probe
+
+Reports ROUGE-1/2/L for both and the delta. `dp_sgd_keras_gemma3_dpsapf.ipynb`
+demonstrates the full mechanism; this script exists so you can iterate on
+the probe implementation without a Jupyter round-trip.
+
+Typical run (single-GPU, ~10-20 min per config on 1B):
+  python examples/dpsapf_validate.py \\
+      --dataset cnn_dailymail --test_run \\
+      --top_k_percent 5 --total_epsilon 4.0
+
+`--test_run` swaps to Gemma3 1B. Drop it for the full 4B model.
+"""
+
+import argparse
+import os
+
+# Deferred imports below: the heavy JAX/Keras/TF stack is imported inside
+# functions so `os.environ['KERAS_BACKEND']` and cache-dir env vars can be
+# set first (they must be in place before `import keras`).
+# pylint: disable=import-outside-toplevel
+
+
+DEFAULT_CACHE_ROOT = "/bigtemp/fzv6en/diffuser_cache"
+
+
+# ---------------------------------------------------------------------------
+# Dataset registry + Keras/LoRA helpers (example-side glue; the DP mechanism
+# itself lives in `jax_privacy.saliency`).
+# ---------------------------------------------------------------------------
+
+DATASET_REGISTRY = {
+    "samsum": {
+        "loader": "tfds",
+        "tfds_name": "samsum",
+        "input_field": "dialogue",
+        "output_field": "summary",
+        "prompt_prefix": "Summarize the following dialogue:\n",
+        "prompt_suffix": "\nSummary:\n",
+        "note": (
+            "~14.7K dialogue/summary pairs. Requires a manual `corpus.7z` "
+            "download to $TFDS_DATA_DIR/downloads/manual/."
+        ),
+    },
+    "cnn_dailymail": {
+        "loader": "tfds",
+        "tfds_name": "cnn_dailymail",
+        "input_field": "article",
+        "output_field": "highlights",
+        "prompt_prefix": "Summarize the following news article:\n",
+        "prompt_suffix": "\nHighlights:\n",
+        "note": (
+            "~287K news articles -> multi-sentence highlights. "
+            "Long inputs. Requires `pip install beautifulsoup4 lxml`."
+        ),
+    },
+    "xsum_hf": {
+        "loader": "hf",
+        "hf_name": "EdinburghNLP/xsum",
+        "input_field": "document",
+        "output_field": "summary",
+        "prompt_prefix": "Summarize the following article in one sentence:\n",
+        "prompt_suffix": "\nSummary:\n",
+        "note": "~204K BBC articles -> 1-sentence summaries via HuggingFace.",
+    },
+}
+
+
+def _make_source_to_gemma3_format(cfg):
+  """tf.data.map fn emitting {prompts, responses} string dicts."""
+  import tensorflow as tf
+
+  in_field, out_field = cfg["input_field"], cfg["output_field"]
+  prefix, suffix = cfg["prompt_prefix"], cfg["prompt_suffix"]
+
+  def fn(d):
+    return {
+        "prompts": tf.strings.join([prefix, d[in_field], suffix]),
+        "responses": d[out_field],
+    }
+
+  return fn
+
+
+def _load_dataset_split(cfg, split_spec):
+  """TFDS vs HuggingFace dispatcher.
+
+  Returns a tf.data.Dataset with known cardinality (needed for DP accounting
+  and reasonable batching downstream).
+  """
+  import tensorflow as tf
+  import tensorflow_datasets as tfds
+
+  if cfg.get("loader") == "hf":
+    try:
+      from datasets import load_dataset  # pytype: disable=import-error
+    except ImportError as e:
+      raise ImportError(
+          "The HuggingFace `datasets` package is required for the xsum_hf "
+          "dataset; install it with `pip install datasets`."
+      ) from e
+    in_field, out_field = cfg["input_field"], cfg["output_field"]
+    hf_ds = load_dataset(cfg["hf_name"], split=split_spec)
+
+    def gen():
+      for ex in hf_ds:
+        yield {in_field: ex[in_field], out_field: ex[out_field]}
+
+    return tf.data.Dataset.from_generator(
+        gen,
+        output_signature={
+            in_field: tf.TensorSpec(shape=(), dtype=tf.string),
+            out_field: tf.TensorSpec(shape=(), dtype=tf.string),
+        },
+    ).apply(tf.data.experimental.assert_cardinality(len(hf_ds)))
+
+  return tfds.load(cfg["tfds_name"], split=split_spec)
+
+
+def _get_lora_candidate_layers(backbone, attn_only=False):
+  """Dense / EinsumDense sublayers of `backbone` eligible for a LoRA adapter."""
+  import keras
+
+  out, seen = [], set()
+  # pylint: disable-next=protected-access
+  for layer in backbone._flatten_layers(recursive=True, include_self=False):
+    if id(layer) in seen:
+      continue
+    if not isinstance(layer, (keras.layers.Dense, keras.layers.EinsumDense)):
+      continue
+    if not (hasattr(layer, "kernel") and hasattr(layer, "enable_lora")):
+      continue
+    if attn_only and "attention" not in layer.path:
+      continue
+    seen.add(id(layer))
+    out.append(layer)
+  return out
+
+
+def _enable_lora_on_paths(backbone, paths, rank):
+  """Enable LoRA on layers whose `.path` is in `paths`; freeze the rest."""
+  p2l = {
+      l.path: l for l in _get_lora_candidate_layers(backbone, attn_only=False)
+  }
+  ids = {id(p2l[p]) for p in paths if p in p2l}
+  backbone.trainable = True
+  backbone._lora_rank = rank  # pylint: disable=protected-access
+  # pylint: disable-next=protected-access
+  for layer in backbone._flatten_layers(include_self=False):
+    if id(layer) in ids:
+      layer.trainable = True
+      layer.enable_lora(rank=rank)
+      bias = getattr(layer, "bias", None)
+      if bias is not None:
+        bias.trainable = False
+    else:
+      layer.trainable = False
+
+
+def _set_env_defaults(cache_root):
+  os.makedirs(cache_root, exist_ok=True)
+  for k, sub in [
+      ("KERAS_HOME", "keras"),
+      ("KAGGLEHUB_CACHE", "kagglehub"),
+      ("TFDS_DATA_DIR", "tfds"),
+      ("HF_HOME", "huggingface"),
+      ("JAX_COMPILATION_CACHE_DIR", "jax_compilation_cache"),
+  ]:
+    os.environ.setdefault(k, os.path.join(cache_root, sub))
+    os.makedirs(os.environ[k], exist_ok=True)
+  os.environ["KERAS_BACKEND"] = "jax"
+  os.environ.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
+  os.environ.setdefault("XLA_PYTHON_CLIENT_MEM_FRACTION", "0.85")
+  os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
+
+
+def parse_args():
+  p = argparse.ArgumentParser(description=__doc__)
+  p.add_argument("--cache_root", default=DEFAULT_CACHE_ROOT)
+  p.add_argument(
+      "--dataset",
+      default="cnn_dailymail",
+      choices=["samsum", "cnn_dailymail", "xsum_hf"],
+  )
+  p.add_argument("--model", default="gemma3_instruct_4b_text")
+  p.add_argument("--sequence_length", type=int, default=1024)
+  p.add_argument("--test_ds_sequence_length", type=int, default=1024)
+  p.add_argument("--epochs", type=int, default=1)
+  p.add_argument("--batch_size", type=int, default=4)
+  p.add_argument("--gradient_accumulation_steps", type=int, default=128)
+  p.add_argument("--test_batch_size", type=int, default=4)
+  p.add_argument("--lora_rank", type=int, default=64)
+  p.add_argument("--learning_rate", type=float, default=3e-3)
+  p.add_argument("--seed", type=int, default=0)
+  # Probe
+  p.add_argument("--probe_samples", type=int, default=50000)
+  p.add_argument("--probe_topk", type=int, default=8)
+  p.add_argument("--probe_noise_multiplier", type=float, default=20.0)
+  p.add_argument("--probe_microbatch_size", type=int, default=4)
+  p.add_argument("--top_k_percent", type=float, default=5.0)
+  # DP
+  p.add_argument("--total_epsilon", type=float, default=4.0)
+  p.add_argument("--delta", type=float, default=2e-5)
+  p.add_argument("--clipping_norm", type=float, default=1e-3)
+  # Smoke
+  p.add_argument("--test_run", action="store_true")
+  p.add_argument(
+      "--skip_baseline",
+      action="store_true",
+      help="Skip the baseline run and only evaluate the probe-selected mask.",
+  )
+  p.add_argument(
+      "--skip_dpsapf",
+      action="store_true",
+      help="Skip the DP-SAPF run; useful to isolate the baseline number.",
+  )
+  return p.parse_args()
+
+
+def apply_test_run(args):
+  if args.test_run:
+    args.model = "gemma3_instruct_1b"
+    args.probe_samples = min(args.probe_samples, 1000)
+  return args
+
+
+def main():
+  args = apply_test_run(parse_args())
+  _set_env_defaults(args.cache_root)
+
+  # Heavy imports go here, after env vars are set.
+  import gc
+  import jax
+  import keras
+  import keras_hub  # pytype: disable=import-error
+
+  from jax_privacy import saliency
+
+  print(f"Dataset: {args.dataset}   Model: {args.model}")
+  print(
+      f"top_k_percent={args.top_k_percent}   total_epsilon={args.total_epsilon}"
+  )
+
+  # ---------- Data + model ----------
+  dataset_cfg = DATASET_REGISTRY[args.dataset]
+  fmt = _make_source_to_gemma3_format(dataset_cfg)
+  train_ds = _load_dataset_split(dataset_cfg, "train").map(fmt)
+  val_ds = _load_dataset_split(dataset_cfg, "validation").map(fmt)
+  test_ds = _load_dataset_split(dataset_cfg, "test").map(fmt)
+
+  train_size = int(train_ds.cardinality().numpy())
+  print(f"train_size={train_size}")
+
+  train_ds_batched = train_ds.shuffle(2048).batch(
+      args.batch_size, drop_remainder=True
+  )
+  val_ds_batched = val_ds.batch(args.batch_size, drop_remainder=True)
+  test_ds_batched = test_ds.batch(args.test_batch_size)
+
+  keras.distribution.set_distribution(keras.distribution.DataParallel())
+
+  # ---------- Probe (via new library API) ----------
+  print("\n--- Probe pass ---")
+  # Load model once for the probe.
+  gemma_lm = keras_hub.models.Gemma3CausalLM.from_preset(args.model)
+  gemma_lm.preprocessor.sequence_length = args.sequence_length
+
+  # Candidates = every attention-projection Dense/EinsumDense kernel.
+  candidate_layers = _get_lora_candidate_layers(
+      gemma_lm.backbone, attn_only=True
+  )
+  candidate_kernel_ids = {id(l.kernel) for l in candidate_layers}
+  trainable_vars = list(gemma_lm.trainable_variables)
+
+  # Boolean list, same order as `trainable_vars` -> pytree-compatible.
+  candidate_mask = [id(v) in candidate_kernel_ids for v in trainable_vars]
+  num_candidates = sum(candidate_mask)
+  select_top_k = max(1, round(num_candidates * args.top_k_percent / 100.0))
+  print(f"num_candidates={num_candidates}   select_top_k={select_top_k}")
+
+  # Loss compatible with `jax_privacy.clipped_grad`:
+  # signature `loss_fn(params, batch)` where batch is a dict with the fields
+  # the Gemma3 preprocessor produces (`x`, `y`, `sw`).
+  ntvars = [v.value for v in gemma_lm.non_trainable_variables]
+  loss_obj = keras.losses.SparseCategoricalCrossentropy(
+      from_logits=True, reduction="sum_over_batch_size"
+  )
+
+  def loss_fn(params, batch):
+    x, y, sw = batch["x"], batch["y"], batch["sw"]
+    # pytype: disable=attribute-error
+    # gemma_lm is None-rebound later in this function to free the ~4GB backbone
+    # before per-config fine-tunes, which triggers a false-positive here.
+    y_pred, _ = gemma_lm.stateless_call(params, ntvars, x, training=False)
+    # pytype: enable=attribute-error
+    return loss_obj(y, y_pred.astype(jax.numpy.float32), sample_weight=sw)
+
+  preproc = gemma_lm.preprocessor
+
+  def probe_batches():
+    """Yields microbatches (dict) shaped for `loss_fn`."""
+    src = (
+        train_ds_batched.unbatch()
+        .take(args.probe_samples)
+        .batch(args.probe_microbatch_size, drop_remainder=True)
+    )
+    for chunk in src:
+      x, y, sw = preproc(chunk)
+      # convert to jax arrays
+      x = {
+          k: jax.numpy.asarray(v.numpy() if hasattr(v, "numpy") else v)
+          for k, v in x.items()
+      }
+      y = jax.numpy.asarray(y.numpy() if hasattr(y, "numpy") else y)
+      sw = (
+          jax.numpy.asarray(sw.numpy() if hasattr(sw, "numpy") else sw)
+          if sw is not None
+          else jax.numpy.ones_like(y, dtype=jax.numpy.float32)
+      )
+      yield {"x": x, "y": y, "sw": sw}
+
+  probe_result = saliency.topk_vote_probe(
+      loss_fn=loss_fn,
+      dataset=probe_batches(),
+      params=[v.value for v in trainable_vars],
+      num_samples=args.probe_samples,
+      vote_top_k=args.probe_topk,
+      select_top_k=select_top_k,
+      noise_multiplier=args.probe_noise_multiplier,
+      candidate_mask=candidate_mask,
+      prng_key=jax.random.PRNGKey(args.seed),
+      sampling_probability=args.probe_samples / train_size,
+      microbatch_size=args.probe_microbatch_size,
+  )
+  print(
+      f"probe: {probe_result.n_seen} samples, "
+      f"kept {select_top_k}/{num_candidates} layers."
+  )
+  # Translate the boolean pytree back to the set of `.path` strings that
+  # `_enable_lora_on_paths` expects.
+  probe_selected_paths = _mask_to_paths(
+      probe_result.selected_mask, trainable_vars, candidate_layers
+  )
+  print("Top-scoring probe-selected layers:")
+  for i, (idx, s) in enumerate(probe_result.ranked_scores[:select_top_k]):
+    print(f"  #{i+1:3d} score={s:.3e}  {_index_to_path(idx, candidate_layers)}")
+
+  # ---------- Baseline mask = keras_hub's `enable_lora()` default ----------
+  # `default_lora_layer_names()` returns a family-agnostic list of leaf names
+  # (e.g. ["query_dense", "value_dense", "query", "value"] for Gemma3), and
+  # `Backbone.enable_lora()` matches by `layer.name`. That's typically
+  # query+value on every attention block — a much stronger reference point
+  # than "adapt every attn projection" since it's what a user gets out of
+  # the box.
+  default_names = set(gemma_lm.backbone.default_lora_layer_names())
+  baseline_selected_paths = {
+      l.path for l in candidate_layers if l.name in default_names
+  }
+  baseline_label = (
+      f"baseline (keras_hub default: {sorted(default_names)}, "
+      f"{len(baseline_selected_paths)} layers)"
+  )
+  print(
+      f"baseline default_lora_layer_names={sorted(default_names)} -> "
+      f"{len(baseline_selected_paths)} layers"
+  )
+
+  # Free the probe-time model + JIT cache before we spin up per-run fine-tunes.
+  # (We rebind to None rather than `del`-ing because pyflakes' F821 check gets
+  # confused by `del` on names captured by nested closures earlier in scope.)
+  gemma_lm = None
+  trainable_vars = None
+  ntvars = None
+  loss_fn = None
+  probe_batches = None
+  gc.collect()
+  jax.clear_caches()
+
+  # ---------- Two DP-SGD runs, matched (eps, delta) ----------
+  runs = []
+  if not args.skip_baseline:
+    runs.append((baseline_label, baseline_selected_paths))
+  if not args.skip_dpsapf:
+    runs.append((
+        f"DP-SAPF (top-{args.top_k_percent}% probe)",
+        probe_selected_paths,
+    ))
+
+  results = {}
+  for label, selected_paths in runs:
+    print(f"\n--- Fine-tune: {label} ---")
+    print(f"selected {len(selected_paths)} layers")
+    rouge = _run_one_config(
+        args,
+        selected_paths,
+        train_size,
+        train_ds_batched,
+        val_ds_batched,
+        test_ds_batched,
+        probe_result,
+    )
+    results[label] = rouge
+    print(f"{label} ROUGE: {rouge}")
+
+  # ---------- Report ----------
+  print("\n=========================================================")
+  print("Summary")
+  print("=========================================================")
+  for label, rouge in results.items():
+    print(f"  {label}")
+    for k, v in rouge.items():
+      print(f"    {k}: {v:.4f}")
+  if len(results) == 2:
+    # pylint: disable-next=unbalanced-tuple-unpacking
+    base, dp = list(results.values())
+    print("\n  DP-SAPF - baseline delta:")
+    for k in base:
+      print(f"    {k}: {dp[k] - base[k]:+.4f}")
+
+
+def _run_one_config(
+    args,
+    selected_paths,
+    train_size,
+    train_ds_batched,
+    val_ds_batched,
+    test_ds_batched,
+    probe_result,
+):
+  """Runs one full DP-SGD fine-tune + ROUGE eval for the given mask.
+
+  Uses `keras_api.make_private` for training. (An earlier version of this
+  script tried to migrate to `jax_privacy.training.DPTrainer`, but bridging
+  Keras stateless_call with DP-SGD hit a "closure-captured constants" vs
+  "params-shaped runtime buffers" tradeoff neither of which we could fit —
+  see the discussion with @ryan112358 on the PR. Reverting until we agree
+  on the intended Keras + DPTrainer pattern.)
+  """
+  import gc
+  import jax
+  import keras
+  import keras_hub  # pytype: disable=import-error
+
+  import dp_accounting
+  from jax_privacy import accounting
+  from jax_privacy import keras_api
+
+  gemma_lm = keras_hub.models.Gemma3CausalLM.from_preset(args.model)
+  gemma_lm.preprocessor.sequence_length = args.sequence_length
+
+  _enable_lora_on_paths(gemma_lm.backbone, selected_paths, args.lora_rank)
+
+  steps_per_epoch = train_size // args.batch_size
+  total_train_steps = args.epochs * steps_per_epoch
+  effective_batch_size = args.batch_size * args.gradient_accumulation_steps
+
+  # Calibrate sigma_train so composed (probe + training) matches target eps.
+  def composed_eps(sigma_train):
+    train_event = accounting.dpsgd_event(
+        noise_multiplier=sigma_train,
+        iterations=total_train_steps,
+        sampling_prob=effective_batch_size / train_size,
+    )
+    total = dp_accounting.ComposedDpEvent([probe_result.dp_event, train_event])
+    acc = dp_accounting.rdp.RdpAccountant()
+    acc.compose(total)
+    return acc.get_epsilon(args.delta)
+
+  # Binary search for sigma_train.
+  lo, hi = 0.1, 10.0
+  while composed_eps(hi) > args.total_epsilon:
+    lo, hi = hi, hi * 2
+  while composed_eps(lo) <= args.total_epsilon and lo > 1e-3:
+    hi, lo = lo, lo * 0.5
+  for _ in range(64):
+    mid = 0.5 * (lo + hi)
+    if composed_eps(mid) > args.total_epsilon:
+      lo = mid
+    else:
+      hi = mid
+    if hi - lo < 1e-3:
+      break
+  sigma_train = hi
+  print(
+      f"total_epsilon={args.total_epsilon} -> sigma_train={sigma_train:.4f}; "
+      f"composed eps ~= {composed_eps(sigma_train):.4f}"
+  )
+
+  dp_cfg = keras_api.DPKerasConfig(
+      epsilon=args.total_epsilon,
+      delta=args.delta,
+      noise_multiplier=sigma_train,
+      clipping_norm=args.clipping_norm,
+      batch_size=args.batch_size,
+      train_steps=total_train_steps,
+      train_size=train_size,
+      gradient_accumulation_steps=args.gradient_accumulation_steps,
+      seed=args.seed,
+  )
+  gemma_lm = keras_api.make_private(gemma_lm, dp_cfg)
+
+  optimizer = keras.optimizers.Adam(
+      learning_rate=args.learning_rate,
+      gradient_accumulation_steps=args.gradient_accumulation_steps,
+  )
+  optimizer.exclude_from_weight_decay(var_names=["bias", "scale"])
+  gemma_lm.compile(
+      loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+      optimizer=optimizer,
+      weighted_metrics=[keras.metrics.SparseCategoricalAccuracy()],
+  )
+  gemma_lm.fit(
+      x=train_ds_batched, epochs=args.epochs, validation_data=val_ds_batched
+  )
+
+  # ROUGE eval
+  import tqdm
+
+  gemma_lm.preprocessor.sequence_length = args.test_ds_sequence_length
+  metric_fns = {
+      "rouge_1": keras_hub.metrics.RougeN(order=1),
+      "rouge_2": keras_hub.metrics.RougeN(order=2),
+      "rouge_l": keras_hub.metrics.RougeL(),
+  }
+
+  def common_prefix(a, b):
+    i = 0
+    while i < len(a) and i < len(b) and a[i] == b[i]:
+      i += 1
+    return i
+
+  for batch in tqdm.tqdm(test_ds_batched):
+    prompts = [p.decode("utf-8") for p in batch["prompts"].numpy()]
+    outputs = gemma_lm.generate(prompts)
+    outputs = [o[common_prefix(p, o) :] for p, o in zip(prompts, outputs)]
+    targets = [s.decode("utf-8") for s in batch["responses"].numpy()]
+    for m in metric_fns.values():
+      m.update_state(targets, outputs)
+
+  rouge = {k: float(m.result()["f1_score"]) for k, m in metric_fns.items()}
+
+  # Clean up before the next config.
+  del gemma_lm, optimizer
+  gc.collect()
+  jax.clear_caches()
+  return rouge
+
+
+def _index_to_path(candidate_local_index, candidate_layers):
+  """Maps a probe-local candidate index back to the layer's `.path`."""
+  return candidate_layers[candidate_local_index].path
+
+
+def _mask_to_paths(selected_mask, trainable_vars, candidate_layers):
+  """Boolean pytree over trainable vars -> set of layer `.path` strings."""
+  id_to_path = {id(l.kernel): l.path for l in candidate_layers}
+  selected_paths = set()
+  for var, is_selected in zip(trainable_vars, selected_mask):
+    if is_selected and id(var) in id_to_path:
+      selected_paths.add(id_to_path[id(var)])
+  return selected_paths
+
+
+if __name__ == "__main__":
+  main()

--- a/examples/dpsapf_validate.py
+++ b/examples/dpsapf_validate.py
@@ -271,6 +271,7 @@ def main():
   import numpy as np
   import tensorflow as tf
 
+  from jax_privacy import accounting
   from jax_privacy import batch_selection
   from jax_privacy import saliency
 
@@ -301,6 +302,11 @@ def main():
       sampling_prob=probe_sampling_probability,
       iterations=1,
       partition_type=batch_selection.PartitionType.INDEPENDENT,
+  )
+  probe_dp_event = accounting.dpsgd_event(
+      noise_multiplier=args.probe_noise_multiplier,
+      iterations=1,
+      sampling_prob=probe_sampling.sampling_prob,
   )
   sampling_seed, probe_noise_seed_sequence = np.random.SeedSequence(
       args.seed
@@ -362,8 +368,8 @@ def main():
   preproc = gemma_lm.preprocessor
 
   # Select each member of the full population independently with probability
-  # q. Keeping the same `probe_sampling` object for the probe call below ties
-  # the implemented sampling mechanism to the emitted DpEvent.
+  # q. The caller-owned event above uses the same sampling strategy's public
+  # probability, tying the implemented mechanism to its accounting.
   selection_mask = np.zeros(train_size, dtype=np.bool_)
   selection_mask[probe_indices] = True
   selection_mask = tf.convert_to_tensor(selection_mask)
@@ -423,7 +429,6 @@ def main():
       noise_multiplier=args.probe_noise_multiplier,
       candidate_mask=candidate_mask,
       prng_key=jax.random.PRNGKey(probe_noise_seed),
-      sampling_strategy=probe_sampling,
       microbatch_size=args.probe_microbatch_size,
   )
   print(f"probe complete: kept {select_top_k}/{num_candidates} layers.")
@@ -491,7 +496,7 @@ def main():
         train_ds_batched,
         val_ds_batched,
         test_ds_batched,
-        probe_result,
+        probe_dp_event,
     )
     results[label] = rouge
     print(f"{label} ROUGE: {rouge}")
@@ -519,7 +524,7 @@ def _run_one_config(
     train_ds_batched,
     val_ds_batched,
     test_ds_batched,
-    probe_result,
+    probe_dp_event,
 ):
   """Runs one full DP-SGD fine-tune + ROUGE eval for the given mask.
 
@@ -549,13 +554,16 @@ def _run_one_config(
   effective_batch_size = args.batch_size * args.gradient_accumulation_steps
 
   # Calibrate sigma_train so composed (probe + training) matches target eps.
+  # These remain separate events because their sampling probabilities and
+  # noise multipliers differ; incrementing the training iterations is not
+  # equivalent in this case.
   def composed_eps(sigma_train):
     train_event = accounting.dpsgd_event(
         noise_multiplier=sigma_train,
         iterations=total_train_steps,
         sampling_prob=effective_batch_size / train_size,
     )
-    total = dp_accounting.ComposedDpEvent([probe_result.dp_event, train_event])
+    total = dp_accounting.ComposedDpEvent([probe_dp_event, train_event])
     acc = dp_accounting.rdp.RdpAccountant()
     acc.compose(total)
     return acc.get_epsilon(args.delta)

--- a/jax_privacy/__init__.py
+++ b/jax_privacy/__init__.py
@@ -22,6 +22,7 @@ from . import experimental
 from . import matrix_factorization
 from . import noise_addition
 from . import optimizers
+from . import saliency
 from . import training
 
 # pylint: disable=g-importing-member

--- a/jax_privacy/_validate.py
+++ b/jax_privacy/_validate.py
@@ -53,6 +53,27 @@ def equal(expected, **kwargs):
       )
 
 
+def instance(expected_type, **kwargs):
+  """Validates that all values are instances of ``expected_type``."""
+  for name, value in kwargs.items():
+    if not isinstance(value, expected_type):
+      raise ValueError(
+          f'Expected {name} to be a {expected_type.__name__}, got '
+          f'{type(value).__name__}.'
+      )
+
+
+def tree_structure(reference, **kwargs):
+  """Validates that all values have the same PyTree structure as reference."""
+  expected = jax.tree.structure(reference)
+  for name, value in kwargs.items():
+    actual = jax.tree.structure(value)
+    if actual != expected:
+      raise ValueError(
+          f'Expected {name} to have PyTree structure {expected}, got {actual}.'
+      )
+
+
 def batch(pytree) -> int:
   """Validates a batch pytree and returns the batch size.
 

--- a/jax_privacy/saliency.py
+++ b/jax_privacy/saliency.py
@@ -19,6 +19,16 @@ Implements the discrete top-k voting probe of DP-SAPF (Gong, Li, Lin, Wang,
 Differentially Private Image Synthesis", USENIX Security 2026,
 https://arxiv.org/abs/2605.30312).
 
+This helper is an LLM-oriented top-k voting adaptation of DP-SAPF rather than
+a verbatim implementation of the paper's image-synthesis method. Prefer the
+probe when a public pretrained model has many candidate parameter leaves and
+saliency is expected to be concentrated in a small, stable subset, so the
+one-time probe cost can be offset by a smaller downstream trainable set. A
+standard all-candidate or default-LoRA baseline may be preferable when the
+candidate set is already small, saliency is diffuse or unstable, or the
+additional privacy and computation cost of the probe cannot be amortized.
+Utility comparisons should use the same total privacy budget.
+
 Per training sample:
   * compute the per-sample gradient (via `jax_privacy.clipped_grad`)
   * restrict to a caller-provided set of candidate pytree leaves

--- a/jax_privacy/saliency.py
+++ b/jax_privacy/saliency.py
@@ -29,62 +29,80 @@ candidate set is already small, saliency is diffuse or unstable, or the
 additional privacy and computation cost of the probe cannot be amortized.
 Utility comparisons should use the same total privacy budget.
 
-Per training sample:
+Per sampled privacy unit:
   * compute the per-sample gradient (via `jax_privacy.clipped_grad`)
   * restrict to a caller-provided set of candidate pytree leaves
   * take L2 norm per candidate leaf
   * vote +1 on the top-`vote_top_k` leaves
 
-The vote vectors are summed across the probe dataset and Gaussian noise is
-added to the histogram (via `noise_addition.gaussian_privatizer`); the top
-`select_top_k` layers by noisy vote count are the selected set. The returned
-mask is a boolean pytree in the same structure as `candidate_mask`, directly
-usable with `optax.masked` for downstream DP-SGD fine-tuning.
+The vote vectors are summed across a Poisson-sampled probe batch and Gaussian
+noise is added to the histogram (via `noise_addition.gaussian_privatizer`); the
+top `select_top_k` layers by noisy vote count are the selected set. The probe
+runs once, separately from the downstream jitted training step. Only its
+batched gradient computation is jitted.
 
-DP analysis: each user contributes a vote vector in `{0,1}^L` with exactly
-`vote_top_k` ones, so the L2 sensitivity under ADD_OR_REMOVE is
-`sqrt(vote_top_k)`. The Gaussian noise added has stddev
-`noise_multiplier * sqrt(vote_top_k)`, matching the standard convention that
-`noise_multiplier` is expressed in units of sensitivity.
+DP analysis: each included privacy unit contributes a vote vector in
+`{0,1}^L` with exactly `vote_top_k` ones, so the L2 sensitivity under
+ADD_OR_REMOVE is `sqrt(vote_top_k)`. Each unit must be independently sampled
+with the public probability in `sampling_strategy`. The Gaussian noise added
+has stddev `noise_multiplier * sqrt(vote_top_k)`, matching the standard
+convention that `noise_multiplier` is expressed in units of sensitivity.
 
 Example usage (not runnable as a doctest — caller supplies `params`,
-`loss_fn`, `probe_batches`, `train_size` from their own model + dataset)::
+`loss_fn`, `full_dataset`, and `train_size` from their model + dataset)::
 
     import jax
     import jax_privacy
     import optax
+    from jax_privacy import batch_selection
     from jax_privacy import saliency
 
     # Boolean pytree same shape as params; True on candidate leaves.
     candidate_mask = jax.tree.map(lambda p: p.ndim == 2, params)
 
+    sampling = batch_selection.CyclicPoissonSampling(
+        sampling_prob=1024 / train_size,
+        iterations=1,
+        partition_type=batch_selection.PartitionType.INDEPENDENT,
+    )
+    indices = next(sampling.batch_iterator(train_size, rng=0))
+    probe_batch = jax.tree.map(lambda x: x[indices], full_dataset)
+
     result = saliency.topk_vote_probe(
         loss_fn=loss_fn,
-        dataset=probe_batches,          # iterable of microbatch-sized batches
+        dataset=probe_batch,
         params=params,
-        num_samples=1024,
         vote_top_k=8,
         select_top_k=16,
         noise_multiplier=6.0,
         candidate_mask=candidate_mask,
         prng_key=jax.random.PRNGKey(0),
-        sampling_probability=1024 / train_size,
+        sampling_strategy=sampling,
     )
 
-    masked_optimizer = optax.masked(optax.adam(1e-3), result.selected_mask)
+    freeze_mask = jax.tree.map(lambda selected: not selected,
+                               result.selected_mask)
+    optimizer = optax.selective_transform(
+        optax.adam(1e-3), freeze_mask=freeze_mask
+    )
     # then compose accounting: dp_accounting.ComposedDpEvent(
     #    [result.dp_event, jax_privacy.accounting.dpsgd_event(...)])
 """
 
 import dataclasses
 import math
-from typing import Any, Callable, Iterable
+from typing import Any, Callable
 
 import dp_accounting
 import jax
 import jax.numpy as jnp
+import numpy as np
+import optax
 
+from jax_privacy import _validate
+from jax_privacy import batch_selection
 from jax_privacy import clipping
+from jax_privacy import noise_addition
 
 
 @dataclasses.dataclass(frozen=True)
@@ -94,13 +112,10 @@ class ProbeResult:
   Attributes:
     selected_mask: Boolean pytree with the same structure as the caller's
       `candidate_mask`. `True` on leaves selected as top by noisy vote count;
-      `False` elsewhere (including on non-candidate leaves). Directly usable
-      as the `mask` argument of `optax.masked`.
+      `False` elsewhere (including on non-candidate leaves).
     ranked_scores: Descending-sorted list of `(candidate_index, noisy_score)`
       tuples. `candidate_index` is the position of the leaf among candidates
       (in the canonical flattening order of `candidate_mask`).
-    n_seen: Number of probe samples actually processed (may be less than
-      `num_samples` if the dataset was exhausted early).
     dp_event: The `dp_accounting.DpEvent` representing the probe's privacy
       cost. Compose with the DP-SGD training event via
       `dp_accounting.ComposedDpEvent([dp_event, training_event])`.
@@ -108,13 +123,12 @@ class ProbeResult:
 
   selected_mask: Any
   ranked_scores: list[tuple[int, float]]
-  n_seen: int
   dp_event: dp_accounting.DpEvent
 
 
 def _candidate_positions(candidate_mask: Any) -> tuple[int, ...]:
   """Positions of True entries in the flattened `candidate_mask`."""
-  flat, _ = jax.tree_util.tree_flatten(candidate_mask)
+  flat, _ = jax.tree.flatten(candidate_mask)
   # bool leaves in the mask pytree may be Python bools, JAX arrays, or numpy;
   # coerce to Python bool for a static tuple usable at trace time.
   return tuple(i for i, m in enumerate(flat) if bool(m))
@@ -124,9 +138,9 @@ def _mask_from_selected(
     candidate_mask: Any, selected_positions: set[int]
 ) -> Any:
   """Builds a same-structure boolean pytree, True only on selected leaves."""
-  flat, treedef = jax.tree_util.tree_flatten(candidate_mask)
+  flat, treedef = jax.tree.flatten(candidate_mask)
   new_flat = [i in selected_positions for i in range(len(flat))]
-  return jax.tree_util.tree_unflatten(treedef, new_flat)
+  return jax.tree.unflatten(treedef, new_flat)
 
 
 def _make_vote_transform(
@@ -136,7 +150,7 @@ def _make_vote_transform(
   num_candidates = len(candidate_positions)
 
   def _vote_transform(grads_pytree: Any) -> jax.Array:
-    flat = jax.tree_util.tree_leaves(grads_pytree)
+    flat = jax.tree.leaves(grads_pytree)
     norms = jnp.stack([
         jnp.linalg.norm(flat[i].astype(jnp.float32))
         for i in candidate_positions
@@ -147,41 +161,80 @@ def _make_vote_transform(
   return _vote_transform
 
 
+def _validate_sampling_strategy(
+    strategy: batch_selection.CyclicPoissonSampling,
+) -> None:
+  """Validates that strategy represents one standard Poisson sample."""
+  _validate.instance(
+      batch_selection.CyclicPoissonSampling, sampling_strategy=strategy
+  )
+  _validate.positive(sampling_probability=strategy.sampling_prob)
+  _validate.equal(
+      1,
+      sampling_iterations=strategy.iterations,
+      sampling_cycle_length=strategy.cycle_length,
+  )
+  _validate.equal(None, truncated_batch_size=strategy.truncated_batch_size)
+  _validate.equal(
+      batch_selection.PartitionType.INDEPENDENT,
+      sampling_partition_type=strategy.partition_type,
+  )
+
+
+def _pad_batch_for_microbatching(
+    dataset: optax.ArrayTree,
+    microbatch_size: int | None,
+) -> tuple[optax.ArrayTree, jax.Array]:
+  """Pads a non-empty batch and returns its padding indicator."""
+  batch_size = _validate.batch(dataset)
+  indices = np.arange(batch_size)
+  if microbatch_size is not None:
+    indices = batch_selection.pad_to_multiple_of(
+        indices,
+        multiple=microbatch_size,
+        microbatch_size=microbatch_size,
+    )
+  is_padding_example = indices < 0
+  safe_indices = np.maximum(indices, 0)
+  dataset = jax.tree.map(lambda x: x[safe_indices], dataset)
+  return dataset, jnp.asarray(is_padding_example)
+
+
 def topk_vote_probe(
     loss_fn: Callable[..., jax.Array],
-    dataset: Iterable[Any],
-    params: Any,
+    dataset: optax.ArrayTree,
+    params: optax.ArrayTree,
     *,
-    num_samples: int,
     vote_top_k: int,
     select_top_k: int,
     noise_multiplier: float,
     candidate_mask: Any,
     prng_key: jax.Array,
-    sampling_probability: float,
-    microbatch_size: int = 1,
-    use_noise: bool = True,
-    batch_argnums: int | tuple[int, ...] = 1,
+    sampling_strategy: batch_selection.CyclicPoissonSampling,
+    microbatch_size: int | None = 1,
 ) -> ProbeResult:
   """Runs the DP top-k voting probe and returns a selection mask.
 
-  Streams microbatches of size `microbatch_size` from `dataset` (up to
-  `num_samples` examples), computes per-sample gradients via
+  This is a one-time pre-training mechanism, separate from the downstream
+  jitted training step. `dataset` must contain the result of exactly one draw
+  from `sampling_strategy`. The function computes per-sample gradients via
   `jax_privacy.clipped_grad`, extracts a one-hot top-`vote_top_k` vote vector
   per example over the leaves selected by `candidate_mask`, sums the vote
-  vectors, and adds Gaussian noise with stddev `noise_multiplier *
-  sqrt(vote_top_k)`. Returns a boolean pytree `selected_mask` with `True` on
-  the `select_top_k` candidate leaves whose noisy vote count is largest.
+  vectors, and adds Gaussian noise. The expensive clipped-gradient call is
+  jitted, and its built-in microbatching performs sequential accumulation.
+
+  The returned privacy event uses the probability from the same
+  `sampling_strategy` object used to construct `dataset`. The sampling RNG,
+  sampled indices, realized Poisson batch size, and noise PRNG key must not be
+  released or predictable.
 
   Args:
     loss_fn: The per-example loss. `loss_fn(params, *batch_args) -> loss`
       following the same convention as `jax_privacy.clipped_grad`.
-    dataset: An iterable yielding microbatches, each already batched along its
-      leading axis to size `microbatch_size`. Iteration stops once
-      `num_samples` examples have been consumed or the iterator is exhausted.
+    dataset: A single batched pytree produced by exactly one draw from
+      `sampling_strategy`. Every leaf must have the same leading dimension.
     params: The model parameters (a pytree). Only used to compute gradients;
       not updated.
-    num_samples: The total number of probe samples to consume.
     vote_top_k: Per-sample voting width. Each sample votes +1 on this many
       candidate leaves. Determines the L2 sensitivity of the mechanism
       (`sqrt(vote_top_k)`).
@@ -193,44 +246,35 @@ def topk_vote_probe(
     candidate_mask: Boolean pytree with the same structure as `params`. Leaves
       set to `True` are considered candidates for selection. Non-candidate
       leaves get no votes and are `False` in the returned `selected_mask`.
-    prng_key: Base PRNG key for the Gaussian noise.
-    sampling_probability: The Poisson-subsampling probability that produced
-      the probe dataset (usually `num_samples / train_size`). Used only to
-      build the returned `DpEvent`. It is the caller's responsibility to
-      ensure the actual sampling matches this value.
-    microbatch_size: The vmap width used inside `clipped_grad`. Trades peak
-      memory (larger) for wall-clock (smaller is slower).
-    use_noise: If `False`, skips the Gaussian noise addition. The returned
-      `dp_event` still describes the mechanism as if noise had been added;
-      the caller loses the DP guarantee in exchange for a deterministic
-      selection (useful for reproducibility experiments).
-    batch_argnums: Which argument(s) of `loss_fn` carry the batch axis;
-      passed through to `jax_privacy.clipped_grad` unchanged.
+    prng_key: Private, unpredictable PRNG key for the Gaussian noise.
+    sampling_strategy: The standard one-shot Poisson strategy used to produce
+      `dataset`. It must have one iteration, cycle length one, no truncation,
+      and `PartitionType.INDEPENDENT`.
+    microbatch_size: The vmap width used internally by `clipped_grad`. The
+      realized Poisson batch is padded automatically when necessary. Trades
+      peak memory (larger) for wall-clock time (smaller is slower).
 
   Returns:
     A `ProbeResult`.
 
   Raises:
-    ValueError: if `candidate_mask` has no `True` leaves, or if `vote_top_k`
-      or `select_top_k` exceed the number of candidates, or if
-      `sampling_probability` is not in `(0, 1]`.
+    ValueError: If an argument, batch, mask, or sampling strategy is invalid.
   """
+  _validate.tree_structure(params, candidate_mask=candidate_mask)
+  batch_size = _validate.batch(dataset)
   candidate_positions = _candidate_positions(candidate_mask)
   num_candidates = len(candidate_positions)
-  if num_candidates == 0:
-    raise ValueError('candidate_mask has no True leaves.')
-  if vote_top_k > num_candidates:
-    raise ValueError(
-        f'vote_top_k={vote_top_k} exceeds num_candidates={num_candidates}.'
-    )
-  if select_top_k > num_candidates:
-    raise ValueError(
-        f'select_top_k={select_top_k} exceeds num_candidates={num_candidates}.'
-    )
-  if not 0.0 < sampling_probability <= 1.0:
-    raise ValueError(
-        f'sampling_probability must be in (0, 1]; got {sampling_probability}.'
-    )
+  _validate.positive(num_candidates=num_candidates)
+  _validate.in_range(
+      1,
+      num_candidates,
+      vote_top_k=vote_top_k,
+      select_top_k=select_top_k,
+  )
+  _validate.non_negative(noise_multiplier=noise_multiplier)
+  if microbatch_size is not None:
+    _validate.positive(microbatch_size=microbatch_size)
+  _validate_sampling_strategy(sampling_strategy)
 
   l2_sensitivity = math.sqrt(vote_top_k)
   vote_transform = _make_vote_transform(candidate_positions, vote_top_k)
@@ -242,47 +286,29 @@ def topk_vote_probe(
   grad_fn = clipping.clipped_grad(
       loss_fn,
       argnums=0,
-      batch_argnums=batch_argnums,
+      batch_argnums=1,
       l2_clip_norm=l2_sensitivity,
       pre_clipping_transform=vote_transform,
       microbatch_size=microbatch_size,
   )
 
-  # JIT the per-microbatch accumulation. Without this, each call retraces
-  # the vmap + grad + pre_clipping_transform pipeline, which is catastrophic
-  # for `microbatch_size=1` (one retrace per sample). Consistent batch shapes
-  # (guaranteed by callers using `drop_remainder=True`) let the traced graph
-  # be reused across chunks.
-  @jax.jit
-  def _accumulate(votes, params, batch):
-    return votes + grad_fn(params, batch)
-
-  total_votes = jnp.zeros((num_candidates,), dtype=jnp.float32)
-  n_seen = 0
-  data_iter = iter(dataset)
-  while n_seen < num_samples:
-    try:
-      batch = next(data_iter)
-    except StopIteration:
-      break
-    total_votes = _accumulate(total_votes, params, batch)
-    # We assume each yielded batch is exactly `microbatch_size`; if the
-    # caller yields ragged batches the accounting will be over-counted by
-    # at most `microbatch_size - 1` examples.
-    n_seen += microbatch_size
-
-  if use_noise:
-    # `noise_addition.gaussian_privatizer` is designed for T-step DP-SGD
-    # loops (it initialises streaming-matrix state whose size scales with T)
-    # and over-allocates when applied to our one-shot histogram noise. A
-    # direct Gaussian draw with the correct stddev gives the identical
-    # mechanism at trivial cost.
-    noise = (noise_multiplier * l2_sensitivity) * jax.random.normal(
-        prng_key, (num_candidates,), dtype=jnp.float32
+  if batch_size:
+    dataset, is_padding_example = _pad_batch_for_microbatching(
+        dataset, microbatch_size
     )
-    noisy_votes = total_votes + noise
+    total_votes = jax.jit(grad_fn)(
+        params, dataset, is_padding_example=is_padding_example
+    )
   else:
-    noisy_votes = total_votes
+    total_votes = jnp.zeros((num_candidates,), dtype=jnp.float32)
+
+  neighboring_relation = dp_accounting.NeighboringRelation.ADD_OR_REMOVE_ONE
+  sensitivity = grad_fn.sensitivity(neighboring_relation)
+  privatizer = noise_addition.gaussian_privatizer(
+      stddev=noise_multiplier * sensitivity,
+      prng_key=prng_key,
+  )
+  noisy_votes, _ = privatizer.update(total_votes, privatizer.init(total_votes))
 
   # Rank candidates by noisy vote count.
   scores = jax.device_get(noisy_votes).tolist()
@@ -294,13 +320,12 @@ def topk_vote_probe(
   selected_mask = _mask_from_selected(candidate_mask, selected_flat_positions)
 
   dp_event: dp_accounting.DpEvent = dp_accounting.PoissonSampledDpEvent(
-      sampling_probability=sampling_probability,
+      sampling_probability=sampling_strategy.sampling_prob,
       event=dp_accounting.GaussianDpEvent(noise_multiplier),
   )
 
   return ProbeResult(
       selected_mask=selected_mask,
       ranked_scores=ranked,
-      n_seen=n_seen,
       dp_event=dp_event,
   )

--- a/jax_privacy/saliency.py
+++ b/jax_privacy/saliency.py
@@ -1,0 +1,296 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DP saliency probe for parameter-selective DP fine-tuning.
+
+Implements the discrete top-k voting probe of DP-SAPF (Gong, Li, Lin, Wang,
+2026, "DP-SAPF: Saliency-Aware Parameter Fine-tuning of Public Models for
+Differentially Private Image Synthesis", USENIX Security 2026,
+https://arxiv.org/abs/2605.30312).
+
+Per training sample:
+  * compute the per-sample gradient (via `jax_privacy.clipped_grad`)
+  * restrict to a caller-provided set of candidate pytree leaves
+  * take L2 norm per candidate leaf
+  * vote +1 on the top-`vote_top_k` leaves
+
+The vote vectors are summed across the probe dataset and Gaussian noise is
+added to the histogram (via `noise_addition.gaussian_privatizer`); the top
+`select_top_k` layers by noisy vote count are the selected set. The returned
+mask is a boolean pytree in the same structure as `candidate_mask`, directly
+usable with `optax.masked` for downstream DP-SGD fine-tuning.
+
+DP analysis: each user contributes a vote vector in `{0,1}^L` with exactly
+`vote_top_k` ones, so the L2 sensitivity under ADD_OR_REMOVE is
+`sqrt(vote_top_k)`. The Gaussian noise added has stddev
+`noise_multiplier * sqrt(vote_top_k)`, matching the standard convention that
+`noise_multiplier` is expressed in units of sensitivity.
+
+Example usage (not runnable as a doctest — caller supplies `params`,
+`loss_fn`, `probe_batches`, `train_size` from their own model + dataset)::
+
+    import jax
+    import jax_privacy
+    import optax
+    from jax_privacy import saliency
+
+    # Boolean pytree same shape as params; True on candidate leaves.
+    candidate_mask = jax.tree.map(lambda p: p.ndim == 2, params)
+
+    result = saliency.topk_vote_probe(
+        loss_fn=loss_fn,
+        dataset=probe_batches,          # iterable of microbatch-sized batches
+        params=params,
+        num_samples=1024,
+        vote_top_k=8,
+        select_top_k=16,
+        noise_multiplier=6.0,
+        candidate_mask=candidate_mask,
+        prng_key=jax.random.PRNGKey(0),
+        sampling_probability=1024 / train_size,
+    )
+
+    masked_optimizer = optax.masked(optax.adam(1e-3), result.selected_mask)
+    # then compose accounting: dp_accounting.ComposedDpEvent(
+    #    [result.dp_event, jax_privacy.accounting.dpsgd_event(...)])
+"""
+
+import dataclasses
+import math
+from typing import Any, Callable, Iterable
+
+import dp_accounting
+import jax
+import jax.numpy as jnp
+
+from jax_privacy import clipping
+
+
+@dataclasses.dataclass(frozen=True)
+class ProbeResult:
+  """Return value of `topk_vote_probe`.
+
+  Attributes:
+    selected_mask: Boolean pytree with the same structure as the caller's
+      `candidate_mask`. `True` on leaves selected as top by noisy vote count;
+      `False` elsewhere (including on non-candidate leaves). Directly usable
+      as the `mask` argument of `optax.masked`.
+    ranked_scores: Descending-sorted list of `(candidate_index, noisy_score)`
+      tuples. `candidate_index` is the position of the leaf among candidates
+      (in the canonical flattening order of `candidate_mask`).
+    n_seen: Number of probe samples actually processed (may be less than
+      `num_samples` if the dataset was exhausted early).
+    dp_event: The `dp_accounting.DpEvent` representing the probe's privacy
+      cost. Compose with the DP-SGD training event via
+      `dp_accounting.ComposedDpEvent([dp_event, training_event])`.
+  """
+
+  selected_mask: Any
+  ranked_scores: list[tuple[int, float]]
+  n_seen: int
+  dp_event: dp_accounting.DpEvent
+
+
+def _candidate_positions(candidate_mask: Any) -> tuple[int, ...]:
+  """Positions of True entries in the flattened `candidate_mask`."""
+  flat, _ = jax.tree_util.tree_flatten(candidate_mask)
+  # bool leaves in the mask pytree may be Python bools, JAX arrays, or numpy;
+  # coerce to Python bool for a static tuple usable at trace time.
+  return tuple(i for i, m in enumerate(flat) if bool(m))
+
+
+def _mask_from_selected(
+    candidate_mask: Any, selected_positions: set[int]
+) -> Any:
+  """Builds a same-structure boolean pytree, True only on selected leaves."""
+  flat, treedef = jax.tree_util.tree_flatten(candidate_mask)
+  new_flat = [i in selected_positions for i in range(len(flat))]
+  return jax.tree_util.tree_unflatten(treedef, new_flat)
+
+
+def _make_vote_transform(
+    candidate_positions: tuple[int, ...], vote_top_k: int
+) -> Callable[[Any], jax.Array]:
+  """Returns a pre_clipping_transform: per-example grad -> top-k vote vector."""
+  num_candidates = len(candidate_positions)
+
+  def _vote_transform(grads_pytree: Any) -> jax.Array:
+    flat = jax.tree_util.tree_leaves(grads_pytree)
+    norms = jnp.stack([
+        jnp.linalg.norm(flat[i].astype(jnp.float32))
+        for i in candidate_positions
+    ])
+    _, top_idx = jax.lax.top_k(norms, k=vote_top_k)
+    return jax.nn.one_hot(top_idx, num_candidates, dtype=jnp.float32).sum(0)
+
+  return _vote_transform
+
+
+def topk_vote_probe(
+    loss_fn: Callable[..., jax.Array],
+    dataset: Iterable[Any],
+    params: Any,
+    *,
+    num_samples: int,
+    vote_top_k: int,
+    select_top_k: int,
+    noise_multiplier: float,
+    candidate_mask: Any,
+    prng_key: jax.Array,
+    sampling_probability: float,
+    microbatch_size: int = 1,
+    use_noise: bool = True,
+    batch_argnums: int | tuple[int, ...] = 1,
+) -> ProbeResult:
+  """Runs the DP top-k voting probe and returns a selection mask.
+
+  Streams microbatches of size `microbatch_size` from `dataset` (up to
+  `num_samples` examples), computes per-sample gradients via
+  `jax_privacy.clipped_grad`, extracts a one-hot top-`vote_top_k` vote vector
+  per example over the leaves selected by `candidate_mask`, sums the vote
+  vectors, and adds Gaussian noise with stddev `noise_multiplier *
+  sqrt(vote_top_k)`. Returns a boolean pytree `selected_mask` with `True` on
+  the `select_top_k` candidate leaves whose noisy vote count is largest.
+
+  Args:
+    loss_fn: The per-example loss. `loss_fn(params, *batch_args) -> loss`
+      following the same convention as `jax_privacy.clipped_grad`.
+    dataset: An iterable yielding microbatches, each already batched along its
+      leading axis to size `microbatch_size`. Iteration stops once
+      `num_samples` examples have been consumed or the iterator is exhausted.
+    params: The model parameters (a pytree). Only used to compute gradients;
+      not updated.
+    num_samples: The total number of probe samples to consume.
+    vote_top_k: Per-sample voting width. Each sample votes +1 on this many
+      candidate leaves. Determines the L2 sensitivity of the mechanism
+      (`sqrt(vote_top_k)`).
+    select_top_k: Number of candidate leaves to keep after ranking by noisy
+      vote count. Must be `<= sum(candidate_mask)`.
+    noise_multiplier: Gaussian noise stddev in units of the L2 sensitivity.
+      The absolute per-bin stddev of the added noise is
+      `noise_multiplier * sqrt(vote_top_k)`.
+    candidate_mask: Boolean pytree with the same structure as `params`. Leaves
+      set to `True` are considered candidates for selection. Non-candidate
+      leaves get no votes and are `False` in the returned `selected_mask`.
+    prng_key: Base PRNG key for the Gaussian noise.
+    sampling_probability: The Poisson-subsampling probability that produced
+      the probe dataset (usually `num_samples / train_size`). Used only to
+      build the returned `DpEvent`. It is the caller's responsibility to
+      ensure the actual sampling matches this value.
+    microbatch_size: The vmap width used inside `clipped_grad`. Trades peak
+      memory (larger) for wall-clock (smaller is slower).
+    use_noise: If `False`, skips the Gaussian noise addition. The returned
+      `dp_event` still describes the mechanism as if noise had been added;
+      the caller loses the DP guarantee in exchange for a deterministic
+      selection (useful for reproducibility experiments).
+    batch_argnums: Which argument(s) of `loss_fn` carry the batch axis;
+      passed through to `jax_privacy.clipped_grad` unchanged.
+
+  Returns:
+    A `ProbeResult`.
+
+  Raises:
+    ValueError: if `candidate_mask` has no `True` leaves, or if `vote_top_k`
+      or `select_top_k` exceed the number of candidates, or if
+      `sampling_probability` is not in `(0, 1]`.
+  """
+  candidate_positions = _candidate_positions(candidate_mask)
+  num_candidates = len(candidate_positions)
+  if num_candidates == 0:
+    raise ValueError('candidate_mask has no True leaves.')
+  if vote_top_k > num_candidates:
+    raise ValueError(
+        f'vote_top_k={vote_top_k} exceeds num_candidates={num_candidates}.'
+    )
+  if select_top_k > num_candidates:
+    raise ValueError(
+        f'select_top_k={select_top_k} exceeds num_candidates={num_candidates}.'
+    )
+  if not 0.0 < sampling_probability <= 1.0:
+    raise ValueError(
+        f'sampling_probability must be in (0, 1]; got {sampling_probability}.'
+    )
+
+  l2_sensitivity = math.sqrt(vote_top_k)
+  vote_transform = _make_vote_transform(candidate_positions, vote_top_k)
+
+  # clipped_grad with L2 clip == sensitivity is a no-op for vote vectors
+  # (they are exactly on the L2 ball of radius sqrt(vote_top_k) by
+  # construction), but it lets us reuse the standard per-example grad + sum
+  # pipeline without extra machinery.
+  grad_fn = clipping.clipped_grad(
+      loss_fn,
+      argnums=0,
+      batch_argnums=batch_argnums,
+      l2_clip_norm=l2_sensitivity,
+      pre_clipping_transform=vote_transform,
+      microbatch_size=microbatch_size,
+  )
+
+  # JIT the per-microbatch accumulation. Without this, each call retraces
+  # the vmap + grad + pre_clipping_transform pipeline, which is catastrophic
+  # for `microbatch_size=1` (one retrace per sample). Consistent batch shapes
+  # (guaranteed by callers using `drop_remainder=True`) let the traced graph
+  # be reused across chunks.
+  @jax.jit
+  def _accumulate(votes, params, batch):
+    return votes + grad_fn(params, batch)
+
+  total_votes = jnp.zeros((num_candidates,), dtype=jnp.float32)
+  n_seen = 0
+  data_iter = iter(dataset)
+  while n_seen < num_samples:
+    try:
+      batch = next(data_iter)
+    except StopIteration:
+      break
+    total_votes = _accumulate(total_votes, params, batch)
+    # We assume each yielded batch is exactly `microbatch_size`; if the
+    # caller yields ragged batches the accounting will be over-counted by
+    # at most `microbatch_size - 1` examples.
+    n_seen += microbatch_size
+
+  if use_noise:
+    # `noise_addition.gaussian_privatizer` is designed for T-step DP-SGD
+    # loops (it initialises streaming-matrix state whose size scales with T)
+    # and over-allocates when applied to our one-shot histogram noise. A
+    # direct Gaussian draw with the correct stddev gives the identical
+    # mechanism at trivial cost.
+    noise = (noise_multiplier * l2_sensitivity) * jax.random.normal(
+        prng_key, (num_candidates,), dtype=jnp.float32
+    )
+    noisy_votes = total_votes + noise
+  else:
+    noisy_votes = total_votes
+
+  # Rank candidates by noisy vote count.
+  scores = jax.device_get(noisy_votes).tolist()
+  ranked = sorted(enumerate(scores), key=lambda kv: kv[1], reverse=True)
+  selected_local_indices = {i for i, _ in ranked[:select_top_k]}
+  selected_flat_positions = {
+      candidate_positions[i] for i in selected_local_indices
+  }
+  selected_mask = _mask_from_selected(candidate_mask, selected_flat_positions)
+
+  dp_event: dp_accounting.DpEvent = dp_accounting.PoissonSampledDpEvent(
+      sampling_probability=sampling_probability,
+      event=dp_accounting.GaussianDpEvent(noise_multiplier),
+  )
+
+  return ProbeResult(
+      selected_mask=selected_mask,
+      ranked_scores=ranked,
+      n_seen=n_seen,
+      dp_event=dp_event,
+  )

--- a/jax_privacy/saliency.py
+++ b/jax_privacy/saliency.py
@@ -29,28 +29,36 @@ candidate set is already small, saliency is diffuse or unstable, or the
 additional privacy and computation cost of the probe cannot be amortized.
 Utility comparisons should use the same total privacy budget.
 
-Per sampled privacy unit:
+Per included privacy unit:
   * compute the per-sample gradient (via `jax_privacy.clipped_grad`)
   * restrict to a caller-provided set of candidate pytree leaves
   * take L2 norm per candidate leaf
   * vote +1 on the top-`vote_top_k` leaves
 
-The vote vectors are summed across a Poisson-sampled probe batch and Gaussian
-noise is added to the histogram (via `noise_addition.gaussian_privatizer`); the
-top `select_top_k` layers by noisy vote count are the selected set. The probe
-runs once, separately from the downstream jitted training step. Only its
-batched gradient computation is jitted.
+The vote vectors are summed across the caller-provided probe batch and Gaussian
+noise is added directly to the histogram; the top `select_top_k` layers by
+noisy vote count are the selected set. The probe runs once, separately from the
+downstream jitted training step. Only its batched gradient computation is
+jitted.
+
+This low-level helper deliberately does not sample records or construct a
+`dp_accounting.DpEvent`. The caller must use a sampling mechanism appropriate
+for its privacy definition and account for that mechanism separately. For
+example, one independent Poisson draw with probability `q` can be represented
+by `accounting.dpsgd_event(noise_multiplier, 1, sampling_prob=q)`.
 
 DP analysis: each included privacy unit contributes a vote vector in
 `{0,1}^L` with exactly `vote_top_k` ones, so the L2 sensitivity under
 ADD_OR_REMOVE is `sqrt(vote_top_k)`. Each unit must be independently sampled
-with the public probability in `sampling_strategy`. The Gaussian noise added
-has stddev `noise_multiplier * sqrt(vote_top_k)`, matching the standard
-convention that `noise_multiplier` is expressed in units of sensitivity.
+if the caller claims Poisson amplification. The Gaussian noise added has stddev
+`noise_multiplier * sqrt(vote_top_k)`, matching the standard convention that
+`noise_multiplier` is expressed in units of sensitivity.
 
 Example usage (not runnable as a doctest — caller supplies `params`,
-`loss_fn`, `full_dataset`, and `train_size` from their model + dataset)::
+`loss_fn`, `full_dataset`, `train_size`, `sampling_rng`, and `noise_key` from
+their model + dataset)::
 
+    import dp_accounting
     import jax
     import jax_privacy
     import optax
@@ -65,7 +73,7 @@ Example usage (not runnable as a doctest — caller supplies `params`,
         iterations=1,
         partition_type=batch_selection.PartitionType.INDEPENDENT,
     )
-    indices = next(sampling.batch_iterator(train_size, rng=0))
+    indices = next(sampling.batch_iterator(train_size, rng=sampling_rng))
     probe_batch = jax.tree.map(lambda x: x[indices], full_dataset)
 
     result = saliency.topk_vote_probe(
@@ -76,8 +84,15 @@ Example usage (not runnable as a doctest — caller supplies `params`,
         select_top_k=16,
         noise_multiplier=6.0,
         candidate_mask=candidate_mask,
-        prng_key=jax.random.PRNGKey(0),
-        sampling_strategy=sampling,
+        prng_key=noise_key,
+    )
+
+    # Sampling and accounting are caller-owned. This event matches the
+    # independent Poisson draw above and the probe's noise multiplier.
+    probe_event = jax_privacy.accounting.dpsgd_event(
+        noise_multiplier=6.0,
+        iterations=1,
+        sampling_prob=sampling.sampling_prob,
     )
 
     freeze_mask = jax.tree.map(lambda selected: not selected,
@@ -85,15 +100,16 @@ Example usage (not runnable as a doctest — caller supplies `params`,
     optimizer = optax.selective_transform(
         optax.adam(1e-3), freeze_mask=freeze_mask
     )
-    # then compose accounting: dp_accounting.ComposedDpEvent(
-    #    [result.dp_event, jax_privacy.accounting.dpsgd_event(...)])
+    total_event = dp_accounting.ComposedDpEvent(
+        [probe_event, jax_privacy.accounting.dpsgd_event(...)]
+    )
 """
 
 import dataclasses
+import functools
 import math
 from typing import Any, Callable
 
-import dp_accounting
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -102,7 +118,6 @@ import optax
 from jax_privacy import _validate
 from jax_privacy import batch_selection
 from jax_privacy import clipping
-from jax_privacy import noise_addition
 
 
 @dataclasses.dataclass(frozen=True)
@@ -116,69 +131,49 @@ class ProbeResult:
     ranked_scores: Descending-sorted list of `(candidate_index, noisy_score)`
       tuples. `candidate_index` is the position of the leaf among candidates
       (in the canonical flattening order of `candidate_mask`).
-    dp_event: The `dp_accounting.DpEvent` representing the probe's privacy
-      cost. Compose with the DP-SGD training event via
-      `dp_accounting.ComposedDpEvent([dp_event, training_event])`.
   """
 
   selected_mask: Any
   ranked_scores: list[tuple[int, float]]
-  dp_event: dp_accounting.DpEvent
-
-
-def _candidate_positions(candidate_mask: Any) -> tuple[int, ...]:
-  """Positions of True entries in the flattened `candidate_mask`."""
-  flat, _ = jax.tree.flatten(candidate_mask)
-  # bool leaves in the mask pytree may be Python bools, JAX arrays, or numpy;
-  # coerce to Python bool for a static tuple usable at trace time.
-  return tuple(i for i, m in enumerate(flat) if bool(m))
 
 
 def _mask_from_selected(
-    candidate_mask: Any, selected_positions: set[int]
+    candidate_mask: Any, selected_candidate_indices: set[int]
 ) -> Any:
-  """Builds a same-structure boolean pytree, True only on selected leaves."""
+  """Builds a mask from indices in the flattened sequence of candidates."""
   flat, treedef = jax.tree.flatten(candidate_mask)
-  new_flat = [i in selected_positions for i in range(len(flat))]
+  new_flat = []
+  candidate_index = 0
+  for is_candidate in flat:
+    if bool(is_candidate):
+      new_flat.append(candidate_index in selected_candidate_indices)
+      candidate_index += 1
+    else:
+      new_flat.append(False)
   return jax.tree.unflatten(treedef, new_flat)
 
 
-def _make_vote_transform(
-    candidate_positions: tuple[int, ...], vote_top_k: int
-) -> Callable[[Any], jax.Array]:
-  """Returns a pre_clipping_transform: per-example grad -> top-k vote vector."""
-  num_candidates = len(candidate_positions)
-
-  def _vote_transform(grads_pytree: Any) -> jax.Array:
-    flat = jax.tree.leaves(grads_pytree)
-    norms = jnp.stack([
-        jnp.linalg.norm(flat[i].astype(jnp.float32))
-        for i in candidate_positions
-    ])
-    _, top_idx = jax.lax.top_k(norms, k=vote_top_k)
-    return jax.nn.one_hot(top_idx, num_candidates, dtype=jnp.float32).sum(0)
-
-  return _vote_transform
-
-
-def _validate_sampling_strategy(
-    strategy: batch_selection.CyclicPoissonSampling,
-) -> None:
-  """Validates that strategy represents one standard Poisson sample."""
-  _validate.instance(
-      batch_selection.CyclicPoissonSampling, sampling_strategy=strategy
+def _vote_transform(
+    grads_pytree: Any,
+    *,
+    candidate_mask: Any,
+    vote_top_k: int,
+) -> jax.Array:
+  """Converts one example's gradient PyTree to a candidate top-k vote."""
+  candidate_grads = [
+      grad
+      for grad, is_candidate in zip(
+          jax.tree.leaves(grads_pytree),
+          jax.tree.leaves(candidate_mask),
+          strict=True,
+      )
+      if bool(is_candidate)
+  ]
+  norms = jnp.stack(
+      [jnp.linalg.norm(grad.astype(jnp.float32)) for grad in candidate_grads]
   )
-  _validate.positive(sampling_probability=strategy.sampling_prob)
-  _validate.equal(
-      1,
-      sampling_iterations=strategy.iterations,
-      sampling_cycle_length=strategy.cycle_length,
-  )
-  _validate.equal(None, truncated_batch_size=strategy.truncated_batch_size)
-  _validate.equal(
-      batch_selection.PartitionType.INDEPENDENT,
-      sampling_partition_type=strategy.partition_type,
-  )
+  _, top_idx = jax.lax.top_k(norms, k=vote_top_k)
+  return jax.nn.one_hot(top_idx, len(candidate_grads), dtype=jnp.float32).sum(0)
 
 
 def _pad_batch_for_microbatching(
@@ -210,29 +205,31 @@ def topk_vote_probe(
     noise_multiplier: float,
     candidate_mask: Any,
     prng_key: jax.Array,
-    sampling_strategy: batch_selection.CyclicPoissonSampling,
     microbatch_size: int | None = 1,
 ) -> ProbeResult:
   """Runs the DP top-k voting probe and returns a selection mask.
 
   This is a one-time pre-training mechanism, separate from the downstream
-  jitted training step. `dataset` must contain the result of exactly one draw
-  from `sampling_strategy`. The function computes per-sample gradients via
+  jitted training step. The function computes per-sample gradients via
   `jax_privacy.clipped_grad`, extracts a one-hot top-`vote_top_k` vote vector
   per example over the leaves selected by `candidate_mask`, sums the vote
   vectors, and adds Gaussian noise. The expensive clipped-gradient call is
   jitted, and its built-in microbatching performs sequential accumulation.
 
-  The returned privacy event uses the probability from the same
-  `sampling_strategy` object used to construct `dataset`. The sampling RNG,
-  sampled indices, realized Poisson batch size, and noise PRNG key must not be
-  released or predictable.
+  Sampling and privacy accounting are intentionally outside this low-level
+  API. The caller must select the records in `dataset` and construct a
+  `DpEvent` matching the actual sampling mechanism and `noise_multiplier`. For
+  independent Poisson sampling under add-or-remove adjacency, use one
+  Poisson-sampled Gaussian event. Without valid sampling amplification, account
+  for the unsampled Gaussian mechanism instead. Sampling randomness, sampled
+  indices, the realized Poisson batch size, and `prng_key` must not be released
+  or predictable.
 
   Args:
     loss_fn: The per-example loss. `loss_fn(params, *batch_args) -> loss`
       following the same convention as `jax_privacy.clipped_grad`.
-    dataset: A single batched pytree produced by exactly one draw from
-      `sampling_strategy`. Every leaf must have the same leading dimension.
+    dataset: A single caller-selected batched pytree. Every leaf must have the
+      same leading dimension.
     params: The model parameters (a pytree). Only used to compute gradients;
       not updated.
     vote_top_k: Per-sample voting width. Each sample votes +1 on this many
@@ -247,23 +244,19 @@ def topk_vote_probe(
       set to `True` are considered candidates for selection. Non-candidate
       leaves get no votes and are `False` in the returned `selected_mask`.
     prng_key: Private, unpredictable PRNG key for the Gaussian noise.
-    sampling_strategy: The standard one-shot Poisson strategy used to produce
-      `dataset`. It must have one iteration, cycle length one, no truncation,
-      and `PartitionType.INDEPENDENT`.
     microbatch_size: The vmap width used internally by `clipped_grad`. The
-      realized Poisson batch is padded automatically when necessary. Trades
-      peak memory (larger) for wall-clock time (smaller is slower).
+      input batch is padded automatically when necessary. Trades peak memory
+      (larger) for wall-clock time (smaller is slower).
 
   Returns:
     A `ProbeResult`.
 
   Raises:
-    ValueError: If an argument, batch, mask, or sampling strategy is invalid.
+    ValueError: If an argument, batch, or mask is invalid.
   """
   _validate.tree_structure(params, candidate_mask=candidate_mask)
   batch_size = _validate.batch(dataset)
-  candidate_positions = _candidate_positions(candidate_mask)
-  num_candidates = len(candidate_positions)
+  num_candidates = sum(bool(x) for x in jax.tree.leaves(candidate_mask))
   _validate.positive(num_candidates=num_candidates)
   _validate.in_range(
       1,
@@ -274,10 +267,13 @@ def topk_vote_probe(
   _validate.non_negative(noise_multiplier=noise_multiplier)
   if microbatch_size is not None:
     _validate.positive(microbatch_size=microbatch_size)
-  _validate_sampling_strategy(sampling_strategy)
 
   l2_sensitivity = math.sqrt(vote_top_k)
-  vote_transform = _make_vote_transform(candidate_positions, vote_top_k)
+  vote_transform = functools.partial(
+      _vote_transform,
+      candidate_mask=candidate_mask,
+      vote_top_k=vote_top_k,
+  )
 
   # clipped_grad with L2 clip == sensitivity is a no-op for vote vectors
   # (they are exactly on the L2 ball of radius sqrt(vote_top_k) by
@@ -302,30 +298,19 @@ def topk_vote_probe(
   else:
     total_votes = jnp.zeros((num_candidates,), dtype=jnp.float32)
 
-  neighboring_relation = dp_accounting.NeighboringRelation.ADD_OR_REMOVE_ONE
-  sensitivity = grad_fn.sensitivity(neighboring_relation)
-  privatizer = noise_addition.gaussian_privatizer(
-      stddev=noise_multiplier * sensitivity,
-      prng_key=prng_key,
+  sensitivity = grad_fn.sensitivity()
+  noise = jax.random.normal(
+      prng_key, total_votes.shape, dtype=total_votes.dtype
   )
-  noisy_votes, _ = privatizer.update(total_votes, privatizer.init(total_votes))
+  noisy_votes = total_votes + noise_multiplier * sensitivity * noise
 
   # Rank candidates by noisy vote count.
   scores = jax.device_get(noisy_votes).tolist()
   ranked = sorted(enumerate(scores), key=lambda kv: kv[1], reverse=True)
   selected_local_indices = {i for i, _ in ranked[:select_top_k]}
-  selected_flat_positions = {
-      candidate_positions[i] for i in selected_local_indices
-  }
-  selected_mask = _mask_from_selected(candidate_mask, selected_flat_positions)
-
-  dp_event: dp_accounting.DpEvent = dp_accounting.PoissonSampledDpEvent(
-      sampling_probability=sampling_strategy.sampling_prob,
-      event=dp_accounting.GaussianDpEvent(noise_multiplier),
-  )
+  selected_mask = _mask_from_selected(candidate_mask, selected_local_indices)
 
   return ProbeResult(
       selected_mask=selected_mask,
       ranked_scores=ranked,
-      dp_event=dp_event,
   )

--- a/tests/saliency_test.py
+++ b/tests/saliency_test.py
@@ -1,0 +1,193 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import chex
+import dp_accounting
+import jax
+import jax.numpy as jnp
+from jax_privacy import batch_selection
+from jax_privacy import saliency
+
+
+def _sampling(probability):
+  return batch_selection.CyclicPoissonSampling(
+      sampling_prob=probability,
+      iterations=1,
+      partition_type=batch_selection.PartitionType.INDEPENDENT,
+  )
+
+
+def _linear_loss(params, batch):
+  return sum(param * jnp.sum(batch[..., i]) for i, param in enumerate(params))
+
+
+def _run_probe(dataset, *, microbatch_size=1, sampling=None, **kwargs):
+  num_candidates = dataset.shape[-1]
+  if sampling is None:
+    sampling = _sampling(1.0)
+  defaults = dict(
+      loss_fn=_linear_loss,
+      dataset=dataset,
+      params=tuple(jnp.array(0.0) for _ in range(num_candidates)),
+      vote_top_k=1,
+      select_top_k=1,
+      noise_multiplier=0.0,
+      candidate_mask=(True,) * num_candidates,
+      prng_key=jax.random.key(0),
+      sampling_strategy=sampling,
+      microbatch_size=microbatch_size,
+  )
+  defaults.update(kwargs)
+  return saliency.topk_vote_probe(**defaults)
+
+
+class SaliencyTest(parameterized.TestCase):
+
+  def test_poisson_sample_and_dp_event_share_strategy(self):
+    population_size = 8
+    probability = 0.5
+    sampling = _sampling(probability)
+    indices = next(sampling.batch_iterator(population_size, rng=7))
+    dataset = jnp.eye(population_size, dtype=jnp.float32)[indices]
+
+    result = _run_probe(
+        dataset,
+        sampling=sampling,
+        select_top_k=2,
+        microbatch_size=3,
+    )
+
+    scores = dict(result.ranked_scores)
+    expected_scores = {i: float(i in indices) for i in range(population_size)}
+    self.assertEqual(scores, expected_scores)
+    self.assertIsInstance(result.dp_event, dp_accounting.PoissonSampledDpEvent)
+    self.assertEqual(result.dp_event.sampling_probability, probability)
+    self.assertIsInstance(result.dp_event.event, dp_accounting.GaussianDpEvent)
+    self.assertEqual(result.dp_event.event.noise_multiplier, 0.0)
+
+  @parameterized.parameters(None, 1, 2, 4)
+  def test_internal_microbatching_matches_unmicrobatched(self, microbatch_size):
+    dataset = jnp.array([
+        [3.0, 0.0, 0.0],
+        [2.0, 0.0, 0.0],
+        [0.0, 4.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 3.0],
+        [1.0, 0.0, 0.0],
+    ])
+
+    result = _run_probe(
+        dataset,
+        microbatch_size=microbatch_size,
+        select_top_k=2,
+    )
+
+    self.assertEqual(result.ranked_scores, [(0, 3.0), (1, 2.0), (2, 1.0)])
+    chex.assert_trees_all_equal(result.selected_mask, (True, True, False))
+
+  def test_empty_poisson_sample_is_supported(self):
+    result = _run_probe(
+        jnp.empty((0, 3), dtype=jnp.float32),
+        sampling=_sampling(0.5),
+        microbatch_size=4,
+    )
+
+    self.assertEqual(dict(result.ranked_scores), {0: 0.0, 1: 0.0, 2: 0.0})
+
+  def test_noise_scale_uses_clipped_grad_sensitivity(self):
+    class FakeGradFn:
+
+      def __init__(self):
+        self.sensitivity = mock.Mock(return_value=7.0)
+
+      def __call__(self, unused_params, unused_dataset, **unused_kwargs):
+        return jnp.zeros((2,), dtype=jnp.float32)
+
+    fake_grad_fn = FakeGradFn()
+
+    class NoNoisePrivatizer:
+
+      def init(self, unused_value):
+        return ()
+
+      def update(self, value, state):
+        return value, state
+
+    with mock.patch.object(
+        saliency.clipping, 'clipped_grad', return_value=fake_grad_fn
+    ), mock.patch.object(
+        saliency.noise_addition,
+        'gaussian_privatizer',
+        return_value=NoNoisePrivatizer(),
+    ) as privatizer:
+      _run_probe(jnp.ones((2, 2)), noise_multiplier=2.0)
+
+    fake_grad_fn.sensitivity.assert_called_once_with(
+        dp_accounting.NeighboringRelation.ADD_OR_REMOVE_ONE
+    )
+    self.assertEqual(privatizer.call_args.kwargs['stddev'], 14.0)
+
+  def test_argument_validation(self):
+    dataset = jnp.ones((2, 3))
+    params = (jnp.array(0.0),) * 3
+    base = dict(
+        loss_fn=_linear_loss,
+        dataset=dataset,
+        params=params,
+        vote_top_k=1,
+        select_top_k=1,
+        noise_multiplier=1.0,
+        candidate_mask=(True, True, True),
+        prng_key=jax.random.key(0),
+        sampling_strategy=_sampling(1.0),
+        microbatch_size=1,
+    )
+    invalid_cases = (
+        ('num_candidates', {'candidate_mask': (False, False, False)}),
+        ('vote_top_k', {'vote_top_k': 0}),
+        ('select_top_k', {'select_top_k': 4}),
+        ('noise_multiplier', {'noise_multiplier': -1.0}),
+        ('microbatch_size', {'microbatch_size': 0}),
+        ('sampling_probability', {'sampling_strategy': _sampling(0.0)}),
+    )
+    for message, overrides in invalid_cases:
+      with self.subTest(message=message), self.assertRaisesRegex(
+          ValueError, message
+      ):
+        saliency.topk_vote_probe(**(base | overrides))
+
+    with self.assertRaisesRegex(ValueError, 'PyTree structure'):
+      saliency.topk_vote_probe(**(base | {'candidate_mask': [True] * 3}))
+
+    with self.assertRaisesRegex(ValueError, 'same size along axis 0'):
+      saliency.topk_vote_probe(
+          **(base | {'dataset': {'x': dataset, 'y': jnp.ones((3,))}})
+      )
+
+  def test_rejects_nonstandard_poisson_strategy(self):
+    sampling = batch_selection.CyclicPoissonSampling(
+        sampling_prob=0.5,
+        iterations=1,
+        partition_type=batch_selection.PartitionType.EQUAL_SPLIT,
+    )
+    with self.assertRaisesRegex(ValueError, 'sampling_partition_type'):
+      _run_probe(jnp.ones((2, 2)), sampling=sampling)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/tests/saliency_test.py
+++ b/tests/saliency_test.py
@@ -20,6 +20,7 @@ import chex
 import dp_accounting
 import jax
 import jax.numpy as jnp
+from jax_privacy import accounting
 from jax_privacy import batch_selection
 from jax_privacy import saliency
 
@@ -36,10 +37,8 @@ def _linear_loss(params, batch):
   return sum(param * jnp.sum(batch[..., i]) for i, param in enumerate(params))
 
 
-def _run_probe(dataset, *, microbatch_size=1, sampling=None, **kwargs):
+def _run_probe(dataset, *, microbatch_size=1, **kwargs):
   num_candidates = dataset.shape[-1]
-  if sampling is None:
-    sampling = _sampling(1.0)
   defaults = dict(
       loss_fn=_linear_loss,
       dataset=dataset,
@@ -49,7 +48,6 @@ def _run_probe(dataset, *, microbatch_size=1, sampling=None, **kwargs):
       noise_multiplier=0.0,
       candidate_mask=(True,) * num_candidates,
       prng_key=jax.random.key(0),
-      sampling_strategy=sampling,
       microbatch_size=microbatch_size,
   )
   defaults.update(kwargs)
@@ -58,7 +56,7 @@ def _run_probe(dataset, *, microbatch_size=1, sampling=None, **kwargs):
 
 class SaliencyTest(parameterized.TestCase):
 
-  def test_poisson_sample_and_dp_event_share_strategy(self):
+  def test_caller_ties_poisson_sample_to_accounting(self):
     population_size = 8
     probability = 0.5
     sampling = _sampling(probability)
@@ -67,18 +65,29 @@ class SaliencyTest(parameterized.TestCase):
 
     result = _run_probe(
         dataset,
-        sampling=sampling,
         select_top_k=2,
         microbatch_size=3,
+    )
+    probe_event = accounting.dpsgd_event(
+        noise_multiplier=0.0,
+        iterations=1,
+        sampling_prob=sampling.sampling_prob,
     )
 
     scores = dict(result.ranked_scores)
     expected_scores = {i: float(i in indices) for i in range(population_size)}
     self.assertEqual(scores, expected_scores)
-    self.assertIsInstance(result.dp_event, dp_accounting.PoissonSampledDpEvent)
-    self.assertEqual(result.dp_event.sampling_probability, probability)
-    self.assertIsInstance(result.dp_event.event, dp_accounting.GaussianDpEvent)
-    self.assertEqual(result.dp_event.event.noise_multiplier, 0.0)
+    self.assertFalse(hasattr(result, 'dp_event'))
+    self.assertIsInstance(probe_event, dp_accounting.SelfComposedDpEvent)
+    self.assertEqual(probe_event.count, 1)
+    self.assertIsInstance(
+        probe_event.event, dp_accounting.PoissonSampledDpEvent
+    )
+    self.assertEqual(probe_event.event.sampling_probability, probability)
+    self.assertIsInstance(
+        probe_event.event.event, dp_accounting.GaussianDpEvent
+    )
+    self.assertEqual(probe_event.event.event.noise_multiplier, 0.0)
 
   @parameterized.parameters(None, 1, 2, 4)
   def test_internal_microbatching_matches_unmicrobatched(self, microbatch_size):
@@ -100,10 +109,9 @@ class SaliencyTest(parameterized.TestCase):
     self.assertEqual(result.ranked_scores, [(0, 3.0), (1, 2.0), (2, 1.0)])
     chex.assert_trees_all_equal(result.selected_mask, (True, True, False))
 
-  def test_empty_poisson_sample_is_supported(self):
+  def test_empty_sample_is_supported(self):
     result = _run_probe(
         jnp.empty((0, 3), dtype=jnp.float32),
-        sampling=_sampling(0.5),
         microbatch_size=4,
     )
 
@@ -120,27 +128,27 @@ class SaliencyTest(parameterized.TestCase):
 
     fake_grad_fn = FakeGradFn()
 
-    class NoNoisePrivatizer:
-
-      def init(self, unused_value):
-        return ()
-
-      def update(self, value, state):
-        return value, state
-
     with mock.patch.object(
         saliency.clipping, 'clipped_grad', return_value=fake_grad_fn
     ), mock.patch.object(
-        saliency.noise_addition,
-        'gaussian_privatizer',
-        return_value=NoNoisePrivatizer(),
-    ) as privatizer:
-      _run_probe(jnp.ones((2, 2)), noise_multiplier=2.0)
+        saliency.jax.random,
+        'normal',
+        return_value=jnp.array([1.0, -1.0]),
+    ) as normal:
+      result = _run_probe(jnp.ones((2, 2)), noise_multiplier=2.0)
 
-    fake_grad_fn.sensitivity.assert_called_once_with(
-        dp_accounting.NeighboringRelation.ADD_OR_REMOVE_ONE
+    fake_grad_fn.sensitivity.assert_called_once_with()
+    normal.assert_called_once_with(mock.ANY, (2,), dtype=jnp.dtype(jnp.float32))
+    self.assertEqual(result.ranked_scores, [(0, 14.0), (1, -14.0)])
+
+  def test_interleaved_candidate_mask_maps_selection_to_full_tree(self):
+    result = _run_probe(
+        jnp.array([[0.0, 100.0, 1.0], [0.0, 100.0, 2.0]]),
+        candidate_mask=(True, False, True),
     )
-    self.assertEqual(privatizer.call_args.kwargs['stddev'], 14.0)
+
+    self.assertEqual(result.ranked_scores, [(1, 2.0), (0, 0.0)])
+    chex.assert_trees_all_equal(result.selected_mask, (False, False, True))
 
   def test_argument_validation(self):
     dataset = jnp.ones((2, 3))
@@ -154,7 +162,6 @@ class SaliencyTest(parameterized.TestCase):
         noise_multiplier=1.0,
         candidate_mask=(True, True, True),
         prng_key=jax.random.key(0),
-        sampling_strategy=_sampling(1.0),
         microbatch_size=1,
     )
     invalid_cases = (
@@ -163,7 +170,6 @@ class SaliencyTest(parameterized.TestCase):
         ('select_top_k', {'select_top_k': 4}),
         ('noise_multiplier', {'noise_multiplier': -1.0}),
         ('microbatch_size', {'microbatch_size': 0}),
-        ('sampling_probability', {'sampling_strategy': _sampling(0.0)}),
     )
     for message, overrides in invalid_cases:
       with self.subTest(message=message), self.assertRaisesRegex(
@@ -178,15 +184,6 @@ class SaliencyTest(parameterized.TestCase):
       saliency.topk_vote_probe(
           **(base | {'dataset': {'x': dataset, 'y': jnp.ones((3,))}})
       )
-
-  def test_rejects_nonstandard_poisson_strategy(self):
-    sampling = batch_selection.CyclicPoissonSampling(
-        sampling_prob=0.5,
-        iterations=1,
-        partition_type=batch_selection.PartitionType.EQUAL_SPLIT,
-    )
-    with self.assertRaisesRegex(ValueError, 'sampling_partition_type'):
-      _run_probe(jnp.ones((2, 2)), sampling=sampling)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

This PR adds a reusable private saliency probe inspired by [DP-SAPF](https://arxiv.org/abs/2605.30312), adapted to LLM/LoRA fine-tuning using per-example top-k voting.

For each example, the probe computes gradient norms over candidate PyTree leaves and casts a k-hot vote for the most salient leaves. The votes are aggregated and noised, producing a boolean selection mask and a `dp_accounting.DpEvent` that can be composed with downstream DP-SGD.

## Changes

- `jax_privacy/saliency.py`
  - Adds `topk_vote_probe(...)`.
  - Reuses `jax_privacy.clipped_grad` with a `pre_clipping_transform`.
  - Returns a PyTree selection mask and the probe's privacy event.
- `jax_privacy/__init__.py`
  - Exports the new `saliency` module.
- `examples/dpsapf_validate.py`
  - Compares Gemma 3 fine-tuning with default LoRA layers against probe-selected layers and reports ROUGE metrics.

The reusable mechanism now lives in the core library; the example contains only model-, dataset-, and evaluation-specific code.

## When to use it

The probe is useful when a public pretrained model has many candidate parameters but saliency is concentrated in a small subset. A standard all-candidate/default-LoRA baseline may be preferable when saliency is diffuse or the probe's additional privacy and computation cost cannot be amortized.

This top-k voting mechanism is an LLM-oriented adaptation inspired by DP-SAPF, not a verbatim implementation of the paper's image-synthesis algorithm.

## Validation

The current PR head passes the repository's lint, unit, heavy-test, and documentation checks.

```bash
CUDA_VISIBLE_DEVICES=0 python examples/dpsapf_validate.py \
  --test_run \
  --dataset cnn_dailymail \
  --top_k_percent 5 \
  --total_epsilon 4.0