### PR TITLE
docs(matrix_factorization): render toeplitz examples as RST literal blocks

### DIFF
--- a/jax_privacy/matrix_factorization/toeplitz.py
+++ b/jax_privacy/matrix_factorization/toeplitz.py
@@ -179,16 +179,14 @@ def materialize_lower_triangular(
 ) -> jax.Array:
   """Creates a lower-triangular Toeplitz matrix.
 
-   Example: If `coef = [a, b, c]` and `n = 6`, then this method returns:
+  Example: If `coef = [a, b, c]` and `n = 6`, then this method returns::
 
-  ```
-  [a 0 0 0 0 0]
-  [b a 0 0 0 0]
-  [c b a 0 0 0]
-  [0 c b a 0 0]
-  [0 0 c b a 0]
-  [0 0 0 c b a]
-  ```
+    [a 0 0 0 0 0]
+    [b a 0 0 0 0]
+    [c b a 0 0 0]
+    [0 c b a 0 0]
+    [0 0 c b a 0]
+    [0 0 0 c b a]
 
   Args:
     coef: The nonzero coefficients of a lower-triangular Toeplitz matrix C, that
@@ -214,15 +212,14 @@ def solve_banded(coef: jax.Array, rhs: jax.Array) -> jax.Array:
   hence we cannot use scipy.linalg.solve_toeplitz.
 
   Example: coef = [a, b, c], rhs = [1, 1, 1, 1, 1, 1], we solve the following
-  system for x
-  ```
-  [a 0 0 0 0 0] [x_0]   [1]
-  [b a 0 0 0 0] [x_1]   [1]
-  [c b a 0 0 0] [x_2] = [1]
-  [0 c b a 0 0] [x_3]   [1]
-  [0 0 c b a 0] [x_4]   [1]
-  [0 0 0 c b a] [x_5]   [1]
-  ```
+  system for x::
+
+    [a 0 0 0 0 0] [x_0]   [1]
+    [b a 0 0 0 0] [x_1]   [1]
+    [c b a 0 0 0] [x_2] = [1]
+    [0 c b a 0 0] [x_3]   [1]
+    [0 0 c b a 0] [x_4]   [1]
+    [0 0 0 c b a] [x_5]   [1]
 
   Args:
     coef: The nonzero coefficients of a lower-triangular Toeplitz matrix C, that


### PR DESCRIPTION
## Summary

Part of #198, item 1 (code formatting).

The docstrings of `materialize_lower_triangular` and `solve_banded` in `jax_privacy/matrix_factorization/toeplitz.py` used Markdown triple-backtick fences, which are not valid RST. ReadTheDocs rendered the matrix examples as plain text with literal ``` characters.

This PR converts both examples to RST `::` literal blocks, consistent with the code-block style already used elsewhere in the library (e.g. `execution_plan.py`). It also removes a stray leading space before the first `Example:` line.

## Note on the other example in #198 item 1

The issue also cites `BandMFExecutionPlanConfig` — that class no longer exists; it was refactored into `BandMFConfig` in `jax_privacy/execution_plan.py`, and its current docstring uses standard `>>>` doctests, so it should already render correctly. If a formatting problem remains there after the next docs build, happy to address it in a follow-up.

## Verification

TensorFlow (required by the full docs build) has no Windows py3.13 wheels, so instead of a full local Sphinx build I rendered both docstrings through the actual pipeline stages: extracted via `ast`, converted with `sphinx.ext.napoleon.GoogleDocstring`, rendered with docutils to HTML. Both examples now emit proper literal blocks with no leaked backtick fences. The ReadTheDocs PR build should confirm end-to-end.

Follow-ups planned for the remaining #198 items (type-alias expansion, MF docs table page, Overview module links).