### PR TITLE
refactor(deps): make chex a test-only dependency

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -148,6 +148,8 @@ disable=R,
         wrong-import-order,
         xrange-builtin,
         zip-builtin-not-iterating,
+        unsubscriptable-object,  # false positive on jax.Array fields
+        invalid-unary-operand-type,  # false positive on jax.Array fields
 
 
 [REPORTS]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ extensions = [
 
 autodoc_type_aliases = {
     'ArrayLike': 'jax.typing.ArrayLike',
-    'ArrayTree': 'chex.ArrayTree',
+    'ArrayTree': 'optax.ArrayTree',
 }
 
 autosummary_generate = True

--- a/jax_privacy/clipping.py
+++ b/jax_privacy/clipping.py
@@ -22,7 +22,6 @@ import math
 import numbers
 from typing import Any, Callable, TypeAlias
 
-import chex
 import dp_accounting
 import jax
 import jax.numpy as jnp
@@ -30,7 +29,7 @@ from jax_privacy import _validate
 import optax
 from optax import microbatching
 
-PyTree: TypeAlias = chex.ArrayTree
+PyTree: TypeAlias = optax.ArrayTree
 AuxiliaryOutput = collections.namedtuple('Aux', ['values', 'grad_norms', 'aux'])
 ClippedTreeAndNorm = collections.namedtuple(
     '_ClippedTreeAndNorm', ['clipped', 'norm']

--- a/jax_privacy/experimental/discrete_gaussian.py
+++ b/jax_privacy/experimental/discrete_gaussian.py
@@ -25,9 +25,9 @@ not catastrophic failures. Roughly speaking, the floating point errors in
 computing the probabilities are added to the delta term in differential privacy.
 """
 
-import chex
 import jax
 import numpy as np
+import optax
 
 
 def _get_sampling_parameters(sigma: float, size: int) -> tuple[float, int]:
@@ -132,10 +132,10 @@ def sample_discrete_gaussian(
 def sample_discrete_gaussian_pytree(
     rng: np.random.Generator,
     sigma: float,
-    pytree: chex.ArrayTree,
+    pytree: optax.ArrayTree,
     oversample: int | None = None,
     dtype: np.typing.DTypeLike = np.int64,
-) -> chex.ArrayTree:
+) -> optax.ArrayTree:
   """Generates discrete Gaussian samples matching the structure of a PyTree.
 
   Specifically, samples a flat array of discrete Gaussian noise for the total

--- a/jax_privacy/keras_api.py
+++ b/jax_privacy/keras_api.py
@@ -49,12 +49,12 @@ import math
 import types
 from typing import Any
 
-import chex
 import dp_accounting
 import jax
 import jax.numpy as jnp
 import keras
 import numpy as np
+import optax
 
 from . import _validate
 from . import accounting
@@ -390,9 +390,9 @@ class _PoissonSampledTrainingDataset(keras.utils.PyDataset):
 
   def __init__(
       self,
-      x: chex.ArrayTree,
-      y: chex.ArrayTree | None,
-      sample_weight: chex.ArrayTree | None,
+      x: optax.ArrayTree,
+      y: optax.ArrayTree | None,
+      sample_weight: optax.ArrayTree | None,
       *,
       dp_params: DPKerasConfig,
       steps_per_epoch: int,
@@ -415,7 +415,7 @@ class _PoissonSampledTrainingDataset(keras.utils.PyDataset):
 
   def __getitem__(
       self, index: int
-  ) -> tuple[chex.ArrayTree, chex.ArrayTree | None, chex.ArrayTree]:
+  ) -> tuple[optax.ArrayTree, optax.ArrayTree | None, optax.ArrayTree]:
     padded_indices = self._epoch_batches[index]
     batched_x = _take_batch_from_tree(self._x, padded_indices)
     batched_y = _take_batch_from_tree(self._y, padded_indices)
@@ -495,7 +495,7 @@ def _pad_batch_indices(indices: np.ndarray, multiple: int) -> np.ndarray:
   return batch_selection.pad_to_multiple_of(indices, multiple)
 
 
-def _tree_batch_size(tree: chex.ArrayTree) -> int:
+def _tree_batch_size(tree: optax.ArrayTree) -> int:
   """Returns and validates the batch size of a pytree of arrays."""
   leaves = jax.tree.leaves(tree)
   # Expected input: a non-empty pytree of random-access arrays whose leaves all
@@ -530,7 +530,9 @@ def _tree_batch_size(tree: chex.ArrayTree) -> int:
   return int(batch_size)
 
 
-def _take_batch_from_leaf(leaf: chex.Array, indices: np.ndarray) -> np.ndarray:
+def _take_batch_from_leaf(
+    leaf: jax.typing.ArrayLike, indices: np.ndarray
+) -> np.ndarray:
   """Slices one batched leaf and zero-fills padded ``-1`` index positions."""
   leaf = np.asarray(leaf)
   valid_positions = indices >= 0
@@ -541,17 +543,17 @@ def _take_batch_from_leaf(leaf: chex.Array, indices: np.ndarray) -> np.ndarray:
 
 
 def _take_batch_from_tree(
-    tree: chex.ArrayTree | None, indices: np.ndarray
-) -> chex.ArrayTree | None:
+    tree: optax.ArrayTree | None, indices: np.ndarray
+) -> optax.ArrayTree | None:
   if tree is None:
     return None
   return jax.tree.map(lambda leaf: _take_batch_from_leaf(leaf, indices), tree)
 
 
 def _build_batch_sample_weight(
-    sample_weight: chex.ArrayTree | None,
+    sample_weight: optax.ArrayTree | None,
     indices: np.ndarray,
-) -> chex.ArrayTree:
+) -> optax.ArrayTree:
   """Builds sample weights that hide synthetic padding examples from Keras."""
   if sample_weight is None:
     return (indices >= 0).astype(np.float32)
@@ -587,8 +589,8 @@ def _maybe_symbolically_build_private_model(
 
 
 def _masked_mean(
-    values: chex.Array, is_padding_example: jax.Array
-) -> chex.Array:
+    values: jax.typing.ArrayLike, is_padding_example: jax.Array
+) -> jax.Array:
   """Averages only the non-padding examples, returning 0 for empty batches."""
   values = jnp.asarray(values)
   if values.ndim == 0:
@@ -763,14 +765,14 @@ def _check_dp_params_aligned_with_fit_args(
     )
 
 
-_XType = chex.ArrayTree
-_YType = chex.ArrayTree
-_SampleWeightType = chex.ArrayTree
-_TrainableVariablesType = chex.ArrayTree
-_NonTrainableVariablesType = list[chex.Numeric]
-_OptimizerVariablesType = list[chex.Numeric]
-_MetricsVariablesType = chex.Numeric
-_UnscaledLossType = chex.Numeric
+_XType = optax.ArrayTree
+_YType = optax.ArrayTree
+_SampleWeightType = optax.ArrayTree
+_TrainableVariablesType = optax.ArrayTree
+_NonTrainableVariablesType = list[jax.typing.ArrayLike]
+_OptimizerVariablesType = list[jax.typing.ArrayLike]
+_MetricsVariablesType = jax.typing.ArrayLike
+_UnscaledLossType = jax.typing.ArrayLike
 _YPredType = _YType
 _KerasInputsDataType = tuple[_XType, _YType | None, _SampleWeightType | None]
 
@@ -788,7 +790,7 @@ _AuxType = tuple[
     _MetricsVariablesType,
 ]
 
-_LogsType = dict[str, chex.Numeric]
+_LogsType = dict[str, jax.typing.ArrayLike]
 
 
 def _dp_train_step(
@@ -895,7 +897,7 @@ def _dp_train_step(
   return logs, state
 
 
-LossFn = Callable[..., tuple[chex.Numeric, _AuxType]]
+LossFn = Callable[..., tuple[jax.typing.ArrayLike, _AuxType]]
 
 
 def _resolve_noise_multiplier(
@@ -931,7 +933,7 @@ def _noised_clipped_grads(
     model: keras.Model | None = None,
     *,
     is_padding_example: jax.Array | None = None,
-) -> tuple[tuple[chex.Numeric, _AuxType], chex.ArrayTree]:
+) -> tuple[tuple[jax.typing.ArrayLike, _AuxType], optax.ArrayTree]:
   """Computes noised and clipped gradients.
 
   Args:

--- a/jax_privacy/matrix_factorization/banded.py
+++ b/jax_privacy/matrix_factorization/banded.py
@@ -15,10 +15,10 @@
 """Class and instances for expressing and optimizing banded strategies."""
 
 from collections.abc import Callable
+import dataclasses
 import functools
 from typing import Any
 
-import chex
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -34,7 +34,8 @@ from . import streaming_matrix
 # pylint:disable=invalid-name
 
 
-@chex.dataclass
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass
 class ColumnNormalizedBanded:
   """A column-normalized banded lower triangular n x n matrix.
 

--- a/jax_privacy/matrix_factorization/buffered_toeplitz.py
+++ b/jax_privacy/matrix_factorization/buffered_toeplitz.py
@@ -24,7 +24,6 @@ import functools
 from typing import Any, TypeAlias
 
 from absl import logging
-import chex
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -48,7 +47,7 @@ from . import toeplitz
 
 
 ThetaPairType: TypeAlias = tuple[jax.Array, jax.Array]
-ScalarFloat: TypeAlias = chex.Numeric | float
+ScalarFloat: TypeAlias = jax.typing.ArrayLike
 
 
 def _gpu_or_cpu_device() -> jax.Device:
@@ -157,7 +156,8 @@ class StreamingMatrixBuilder:
     )
 
 
-@chex.dataclass
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass
 class BufferedToeplitz:
   """A lower-triangular Toeplitz C parameterized as a BLT.
 
@@ -832,7 +832,7 @@ class Parameterization:
     loss_fn: The loss function to optimize.
   """
 
-  params_from_blt: Callable[[BufferedToeplitz], chex.ArrayTree]
+  params_from_blt: Callable[[BufferedToeplitz], optax.ArrayTree]
   blt_and_inverse_from_params: Callable[
       [Any],
       tuple[BufferedToeplitz, BufferedToeplitz],
@@ -880,7 +880,7 @@ class Parameterization:
 
   def get_loss_fn(
       self, loss_fn: LossFn
-  ) -> Callable[[chex.ArrayTree], ScalarFloat]:
+  ) -> Callable[[optax.ArrayTree], ScalarFloat]:
     """Returns a loss function for the parameterization."""
     return lambda params: loss_fn.penalized_loss(
         *self.blt_and_inverse_from_params(params)
@@ -1146,7 +1146,7 @@ def optimize(
 
 
 def geometric_sum(
-    a: jax.Array, r: jax.Array, num: chex.Numeric = jnp.inf
+    a: jax.Array, r: jax.Array, num: jax.typing.ArrayLike = jnp.inf
 ) -> jax.Array:
   """Sum a + a*r + a*r**2 + ... + a*r**(num-1) (or limit if num=jnp.inf).
 
@@ -1288,7 +1288,9 @@ def blt_pair_from_theta_pair(
 
 @jax.jit
 @require_buf_decay_less_eq_one
-def sensitivity_squared(blt: BufferedToeplitz, n: chex.Numeric) -> float:
+def sensitivity_squared(
+    blt: BufferedToeplitz, n: jax.typing.ArrayLike
+) -> float:
   """Computes sensitivity**2 for a BLT strategy matrix C.
 
   See https://arxiv.org/pdf/2404.16706 Lemma 5.3
@@ -1483,7 +1485,9 @@ def robust_max_error_Gamma_jk(
 
 
 @jax.jit
-def iteration_error(inv_blt: BufferedToeplitz, i: chex.Array) -> jax.Array:
+def iteration_error(
+    inv_blt: BufferedToeplitz, i: jax.typing.ArrayLike
+) -> jax.Array:
   """Computes the error on iteration `i` which is also the max error.
 
   That is, for a Buffered Linear Toeplitz matrix, the max error from iteration 0
@@ -1526,7 +1530,7 @@ def iteration_error(inv_blt: BufferedToeplitz, i: chex.Array) -> jax.Array:
 
 
 @jax.jit
-def max_error(inv_blt: BufferedToeplitz, n: chex.Array) -> jax.Array:
+def max_error(inv_blt: BufferedToeplitz, n: jax.typing.ArrayLike) -> jax.Array:
   """Returns the max squared error for any iteration 0, ..., n-1."""
   # Note: For a BLT, the iteration error is increasing in `i`, so:
   return iteration_error(inv_blt, n - 1)

--- a/jax_privacy/matrix_factorization/optimization.py
+++ b/jax_privacy/matrix_factorization/optimization.py
@@ -18,12 +18,11 @@ from collections.abc import Callable
 import dataclasses
 from typing import Any, TypeAlias, TypeVar
 
-import chex
 import jax
 import jax.numpy as jnp
 import optax
 
-ParamT = TypeVar('ParamT', bound=chex.ArrayTree)
+ParamT = TypeVar('ParamT', bound=optax.ArrayTree)
 
 DEFAULT_OPTIMIZER = optax.lbfgs(
     memory_size=1, linesearch=optax.scale_by_backtracking_linesearch(128)
@@ -44,8 +43,8 @@ class CallbackArgs:
 
   step: int
   loss: jnp.ndarray
-  grad: chex.ArrayTree | None
-  params: chex.ArrayTree
+  grad: optax.ArrayTree | None
+  params: optax.ArrayTree
   state: Any
 
 

--- a/jax_privacy/matrix_factorization/streaming_matrix.py
+++ b/jax_privacy/matrix_factorization/streaming_matrix.py
@@ -20,12 +20,11 @@ from collections.abc import Callable
 import dataclasses
 from typing import Any, Generic, TypeAlias, TypeVar
 
-import chex
 import jax
 from jax import numpy as jnp
+import optax
 
-
-State = TypeVar('State', bound=chex.ArrayTree)
+State = TypeVar('State', bound=optax.ArrayTree)
 Shape: TypeAlias = tuple[int, ...]
 ShapePyTree = Any
 
@@ -77,8 +76,10 @@ class StreamingMatrix(Generic[State]):
       (next_input, current_state).
   """
 
-  init_multiply: Callable[[chex.ArrayTree], State]
-  multiply_next: Callable[[chex.ArrayTree, State], tuple[chex.ArrayTree, State]]
+  init_multiply: Callable[[optax.ArrayTree], State]
+  multiply_next: Callable[
+      [optax.ArrayTree, State], tuple[optax.ArrayTree, State]
+  ]
 
   @classmethod
   def from_array_implementation(

--- a/jax_privacy/sharding_utils.py
+++ b/jax_privacy/sharding_utils.py
@@ -31,9 +31,9 @@ Differentially Private ML](https://arxiv.org/abs/2405.15913) and in
 import math
 from typing import Any, Callable, TypeAlias
 
-import chex
 import jax
 import numpy as np
+import optax
 
 
 PyTree: TypeAlias = Any
@@ -285,9 +285,9 @@ def _parallel_sample(
 
 def parallel_sample_pytree(
     rng: np.random.Generator,
-    struct: chex.ArrayTree,
+    struct: optax.ArrayTree,
     sampler: Callable[..., np.ndarray] = np.random.Generator.standard_normal,
-) -> chex.ArrayTree:
+) -> optax.ArrayTree:
   """Sample a pytree with numpy and convert it to a sharded JAX pytree.
 
   This function is intended to bridge the gap between JAX programs and

--- a/jax_privacy/training.py
+++ b/jax_privacy/training.py
@@ -28,7 +28,6 @@ import functools
 from typing import Protocol, TypeAlias
 
 from absl import logging
-import chex
 import jax
 import jax_privacy
 from jax_privacy import _validate
@@ -45,13 +44,13 @@ DPExecutionPlan = execution_plan.DPExecutionPlan
 PerformanceFlags = execution_plan.PerformanceFlags
 
 Loss: TypeAlias = jax.Array
-Aux: TypeAlias = chex.ArrayTree
+Aux: TypeAlias = optax.ArrayTree
 PerExampleAux: TypeAlias = jax_privacy.clipping.AuxiliaryOutput
-Batch: TypeAlias = chex.ArrayTree
-Dataset: TypeAlias = chex.ArrayTree
-Params: TypeAlias = chex.ArrayTree
-OptState: TypeAlias = chex.ArrayTree
-NoiseState: TypeAlias = chex.ArrayTree
+Batch: TypeAlias = optax.ArrayTree
+Dataset: TypeAlias = optax.ArrayTree
+Params: TypeAlias = optax.ArrayTree
+OptState: TypeAlias = optax.ArrayTree
+NoiseState: TypeAlias = optax.ArrayTree
 PrecompiledFuture: TypeAlias = concurrent.futures.Future[jax.stages.Compiled]
 
 # Shared thread pool for background ahead-of-time compilation.
@@ -97,7 +96,8 @@ class LossFn(Protocol):
     ...
 
 
-@chex.dataclass(frozen=True, kw_only=True)
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class TrainingState:
   """Container for the state of the training loop."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "numpy>=2.0.0",
     "optax @ git+https://github.com/google-deepmind/optax.git",
     "scipy>=1.9.2",
-    "chex>=0.1.91",
 ]
 
 [project.optional-dependencies]
@@ -48,6 +47,7 @@ lint = [
 ]
 
 test = [
+    "chex>=0.1.91",
     "pytest>=7.2.0",
     "pytest-xdist>=2.0.0",
     "pytest-cov>=4.0.0",


### PR DESCRIPTION
Closes #303.

Removes `chex` from the core library so it is only needed for tests, as requested in #303.

## Changes
- **`chex.ArrayTree` → `optax.ArrayTree`** across `clipping`, `keras_api`, `sharding_utils`, `training`, `discrete_gaussian`, `buffered_toeplitz`, `optimization`, `streaming_matrix`.
- **`chex.Numeric` / `chex.Array` → `jax.typing.ArrayLike`** (inputs) / **`jax.Array`** (outputs), following the [type-annotations JEP](https://jax.readthedocs.io/en/latest/jep/12049-type-annotations.html) that `buffered_toeplitz` already cites.
- **`@chex.dataclass` → `@jax.tree_util.register_dataclass` + `@dataclasses.dataclass`** on `TrainingState`, `ColumnNormalizedBanded`, and `BufferedToeplitz`. All fields are pytree *data* fields in each of these, so no `jax.tree.static()` annotations are needed and the prior flatten/unflatten/`tree_map` behavior is preserved.
- **`pyproject.toml`**: `chex` moved from `dependencies` to the `[test]` optional-dependencies group.
- **`docs/conf.py`**: `autodoc_type_aliases['ArrayTree']` updated to `optax.ArrayTree`.

## Notes
- `optax.ArrayTree` is a strict superset of `chex.ArrayTree` (it additionally permits Python scalar leaves), so the annotation change only widens the accepted types.
- Verified the three dataclass conversions preserve chex pytree semantics (leaf count/ordering, flatten/unflatten roundtrip, `tree_map`, frozen enforcement, and `jit` tracing of all fields) against the original `@chex.dataclass` definitions.
- Formatting checked with `pyink` (repo config).