### PR TITLE
Compute clipping L2 norm in at least float32 to preserve the sensitivity bound

### DIFF
--- a/jax_privacy/clipping.py
+++ b/jax_privacy/clipping.py
@@ -169,7 +169,19 @@ def clip_pytree(
     raise ValueError(f'clip_norm must be non-negative, got {clip_norm=}.')
 
   clip_norm = jnp.maximum(clip_norm, 0.0)
-  l2_norm = optax.tree.norm(pytree)
+  # Accumulate the squared norm in at least float32 precision: accumulating in
+  # the leaf dtype can underflow or overflow for low-precision leaves (e.g.
+  # float16), producing a norm (and scale) that silently violates the
+  # clip_norm bound. Upcasting one leaf at a time (fused under jit) avoids
+  # materializing a float32 copy of the whole pytree.
+  l2_norm = jnp.sqrt(
+      sum(
+          optax.tree.norm(
+              x.astype(jnp.promote_types(x.dtype, jnp.float32)), squared=True
+          )
+          for x in jax.tree.leaves(pytree)
+      )
+  )
   scale = jnp.minimum(1.0, clip_norm / l2_norm)
   if rescale_to_unit_norm:
     scale = jax.lax.select(clip_norm > 0, scale / clip_norm, 1 / l2_norm)

--- a/tests/clipping_test.py
+++ b/tests/clipping_test.py
@@ -141,6 +141,53 @@ class ClipPyTreeTest(parameterized.TestCase):
     self.assertTrue(jnp.isfinite(norm))
     chex.assert_tree_all_finite(clipped)
     self.assertLessEqual(optax.tree.norm(clipped), 1.0)
+    # The output must be `pytree * min(1, clip_norm / norm) / clip_norm` (in
+    # particular, it must not be silently zeroed out).
+    true_norm = optax.tree.norm(pytree.astype(jnp.float32))
+    expected_norm = jnp.minimum(true_norm / clip_norm, 1.0)
+    self.assertAlmostEqual(
+        optax.tree.norm(clipped.astype(jnp.float32)), expected_norm, delta=0.01
+    )
+
+  @parameterized.parameters(
+      *cartesian_product(
+          dtype=[jnp.float16, jnp.bfloat16],
+          rescale_to_unit_norm=[True, False],
+      )
+  )
+  def test_clip_pytree_low_precision_norm_no_underflow(
+      self, dtype, rescale_to_unit_norm
+  ):
+    """Norm accumulation must not underflow for low-precision leaves."""
+    # The elementwise squares (1e-8) underflow to 0 when computed in float16,
+    # in which case a leaf-dtype norm is reported as 0 and the tree is
+    # returned unclipped despite its norm exceeding clip_norm.
+    pytree = jnp.full((10_000,), 1e-4, dtype=dtype)
+    clip_norm = 1e-3
+    clipped, norm = clipping.clip_pytree(
+        pytree, clip_norm, rescale_to_unit_norm=rescale_to_unit_norm
+    )
+    true_norm = optax.tree.norm(pytree.astype(jnp.float32))
+    self.assertAlmostEqual(norm, true_norm, delta=1e-3 * true_norm)
+    bound = 1.0 if rescale_to_unit_norm else clip_norm
+    # Rounding the output to a low-precision (possibly subnormal) dtype can
+    # exceed the bound by a small relative error.
+    self.assertLessEqual(
+        optax.tree.norm(clipped.astype(jnp.float32)), bound * 1.01
+    )
+
+  def test_clip_pytree_float16_finite_input_norm_does_not_overflow(self):
+    """A finite float16 tree must not be zeroed due to norm overflow."""
+    # The squared norm (160_000) overflows float16's max value (65_504), so
+    # leaf-dtype accumulation reports an inf norm and the all-finite tree
+    # would be wrongly zeroed out by nan_safe handling downstream.
+    pytree = jnp.full((10_000,), 4.0, dtype=jnp.float16)
+    clipped, norm = clipping.clip_pytree(pytree, 1.0)
+    self.assertTrue(jnp.isfinite(norm))
+    self.assertAlmostEqual(norm, 400.0, delta=0.4)
+    self.assertAlmostEqual(
+        optax.tree.norm(clipped.astype(jnp.float32)), 1.0, delta=1e-3
+    )
 
   def test_clip_pytree_per_layer_full_clip_norm_tree(self):
     """Tests per-layer clipping with complete clip_norm tree."""


### PR DESCRIPTION
## Problem
`clip_pytree` computed the global L2 norm in the leaf dtype. For float16 gradient trees the sum of squares can underflow to 0 — the tree is returned **unclipped**, violating the sensitivity bound that DP noise calibration assumes — or overflow to inf for all-finite inputs, in which case the `nan_safe` norm check silently zeroes the example.

## Fix
Accumulate per-leaf squared norms in at least float32 (no materialization of an upcast tree; per-leaf reduction only, keeping the memory profile unchanged).

## Testing
Added float16 regression tests: underflow-to-0 (must clip), overflow-to-inf (must not zero finite grads), and the `rescale_to_unit_norm` variant. All existing clipping tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)