### PR TITLE
Fix BandMF noise stddev and rmse to use the realized strategy column norm

### DIFF
--- a/jax_privacy/execution_plan.py
+++ b/jax_privacy/execution_plan.py
@@ -210,7 +210,9 @@ class BandMFConfig:
       rather than add-remove). If specified, the dataset will be partitioned
       using `batch_selection.PartitionType.EQUAL_SPLIT`, and otherwise it will
       be partitioned using `batch_selection.PartitionType.INDEPENDENT`.
-    column_normalize: Whether to column-normalize the strategy matrix.
+    column_normalize: Whether to column-normalize the strategy matrix. If True,
+      each column of the realized strategy matrix is rescaled to have L2 norm
+      1.0, which makes the mechanism invariant to the scale of `strategy`.
   """
 
   iterations: int
@@ -251,15 +253,22 @@ class BandMFConfig:
     return len(self.strategy)
 
   @property
+  def _max_column_norm(self) -> float:
+    """Maximum L2 column norm of the realized strategy matrix."""
+    if self.column_normalize:
+      return 1.0
+    return float(np.linalg.norm(self.strategy))
+
+  @property
   def rmse(self) -> float:
     """Root mean squared error of the mechanism on the prefix-sum workload.
 
     Requires the config to be calibrated (noise_multiplier must be set).
-    The strategy's column norm is already accounted for via noise_multiplier
-    (the actual noise stddev is noise_multiplier * column_norm), so we do not
-    normalize here. This method normalizes by ``expected_participations``
-    so that you can fairly compare RMSE across instances with different
-    expected participations.
+    The actual noise stddev is noise_multiplier * max_column_norm (see
+    `make`), so the error includes the same column norm factor and is
+    invariant to the scale of the strategy. This method normalizes by
+    ``expected_participations`` so that you can fairly compare RMSE across
+    instances with different expected participations.
 
     Returns:
       The RMSE per query, in units of the clipped gradient.
@@ -269,8 +278,16 @@ class BandMFConfig:
     """
     self._check_calibrated()
     strategy = np.asarray(self.strategy)
+    if self.column_normalize:
+      # Approximates the column-normalized strategy realized by `make`, which
+      # additionally rescales the last num_bands - 1 columns.
+      strategy = strategy / np.linalg.norm(strategy)
     errors = toeplitz.per_query_error(strategy_coef=strategy, n=self.iterations)
-    coefficient = self.noise_multiplier / self.expected_participations
+    coefficient = (
+        self.noise_multiplier
+        * self._max_column_norm
+        / self.expected_participations
+    )
     return float(coefficient * np.sqrt(np.mean(errors)))
 
   @property
@@ -431,7 +448,7 @@ class BandMFConfig:
         partition_type=self._partition_type,
     )
 
-    max_column_norm = np.linalg.norm(self.strategy)
+    max_column_norm = self._max_column_norm
     column_normalize_for_n = self.iterations if self.column_normalize else None
     noising_matrix = toeplitz.inverse_as_streaming_matrix(
         self.strategy, column_normalize_for_n

--- a/tests/execution_plan_test.py
+++ b/tests/execution_plan_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
+
 from absl.testing import absltest
 from absl.testing import parameterized
 import dp_accounting
@@ -127,6 +129,62 @@ class ExecutionPlanTest(parameterized.TestCase):
     )
     plan = config.make(flags)
     self.assertIsInstance(plan, execution_plan.DPExecutionPlan)
+
+  @parameterized.parameters(
+      {"column_normalize": False},
+      {"column_normalize": True},
+  )
+  def test_noise_stddev_matches_dp_event_for_scaled_strategy(
+      self, column_normalize
+  ):
+    # With num_bands=1, the mechanism adds independent Gaussian noise to each
+    # iterate with stddev noise_multiplier * sensitivity (here 1.0), as claimed
+    # by the dp_event, regardless of the scale of the strategy.
+    config = BandMFConfig(
+        iterations=4,
+        expected_participations=4,
+        strategy=np.array([0.5]),
+        noise_multiplier=1.0,
+        column_normalize=column_normalize,
+    )
+    plan = config.make(execution_plan.PerformanceFlags(noise_seed=0))
+    grads = np.zeros(200_000, dtype=np.float32)
+    state = plan.noise_addition_transform.init(grads)
+    noise, _ = plan.noise_addition_transform.update(grads, state)
+    self.assertAlmostEqual(float(np.std(noise)), 1.0, delta=0.02)
+
+  @parameterized.parameters(
+      {"column_normalize": False},
+      {"column_normalize": True},
+  )
+  def test_rmse_invariant_to_strategy_scale(self, column_normalize):
+    # Scaling the strategy scales the noise stddev up and the noising matrix
+    # down, leaving the mechanism (and hence its rmse) unchanged.
+    config = BandMFConfig(
+        iterations=8,
+        expected_participations=2,
+        strategy=np.array([1.0, 0.5, 0.2]),
+        noise_multiplier=1.0,
+        column_normalize=column_normalize,
+    )
+    scaled = dataclasses.replace(
+        config, strategy=2 * np.asarray(config.strategy)
+    )
+    self.assertAlmostEqual(config.rmse, scaled.rmse, places=6)
+
+  def test_rmse_matches_independent_noise_for_one_band(self):
+    # With num_bands=1, the mechanism adds independent noise with stddev
+    # noise_multiplier to each iterate, so the error on prefix-sum query i is
+    # noise_multiplier * sqrt(i), regardless of the scale of the strategy.
+    iterations = 8
+    config = BandMFConfig(
+        iterations=iterations,
+        expected_participations=2,
+        strategy=np.array([0.5]),
+        noise_multiplier=3.0,
+    )
+    expected = 3.0 * np.sqrt(np.mean(np.arange(1, iterations + 1))) / 2
+    self.assertAlmostEqual(config.rmse, expected, places=5)
 
   def test_rmse_requires_calibration(self):
     config = BandMFConfig.default(


### PR DESCRIPTION
## Problem
`BandMFConfig.make()` scales the noise stddev by the input strategy's max column norm even when `column_normalize=True`, although in that case the *realized* strategy matrix has unit column norms. A strategy with column norm 0.5 injects **half** the noise the returned `dp_event` claims — a silent DP guarantee violation. Conversely `BandMFConfig.rmse()` omits the column-norm factor, so two configurations realizing the identical mechanism report different rmse depending on the input strategy's scale.

## Fix
Use a column-norm factor of 1.0 for noise calibration when `column_normalize=True`, and include the same factor in `rmse()` so it is scale-invariant.

## Testing
Added tests asserting (1) the empirical noise stddev matches the dp_event calibration under `column_normalize` with a non-unit-norm strategy, and (2) rmse is invariant to strategy rescaling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)