### PR TITLE
Fix dense privatizer crash with SupportedStrategies.ZERO

### DIFF
--- a/jax_privacy/noise_addition.py
+++ b/jax_privacy/noise_addition.py
@@ -215,7 +215,7 @@ def _gaussian_linear_combination(
     return partial + coef * noise
 
   lower_bound, upper_bound = _compute_loop_bounds(matrix_row)
-  loop_state = jnp.zeros(shape, dtype)
+  loop_state = jnp.zeros(shape, dtype, out_sharding=out_sharding)
   return jax.lax.fori_loop(lower_bound, upper_bound, loop_body, loop_state)
 
 

--- a/tests/distributed_noise_generation_test.py
+++ b/tests/distributed_noise_generation_test.py
@@ -45,6 +45,10 @@ def buffered_toeplitz_noising_matrix_fn():
   return blt.inverse_as_streaming_matrix()
 
 
+def dense_noising_matrix_fn():
+  return jnp.eye(4) + jnp.tril(jnp.full((4, 4), 0.25))
+
+
 class ShardedNoiseGenerationTest(parameterized.TestCase):
 
   def setUp(self):
@@ -64,6 +68,7 @@ class ShardedNoiseGenerationTest(parameterized.TestCase):
   @parameterized.named_parameters(
       ('blt', buffered_toeplitz_noising_matrix_fn),
       ('bandmf', banded_toeplitz_noising_matrix_fn),
+      ('dense', dense_noising_matrix_fn),
       ('dpsgd', streaming_matrix.identity),
       ('prefix', streaming_matrix.prefix_sum),
       ('momentum', streaming_matrix.momentum_sgd_matrix),


### PR DESCRIPTION
## Problem
`_gaussian_linear_combination` initializes its `fori_loop` carry without `out_sharding`, so under an explicit mesh with `SupportedStrategies.ZERO` the replicated carry input does not match the sharded loop-body output and `jax.lax.fori_loop` raises a TypeError. Dense noising matrices cannot be used with ZeRO-style sharding at all.

## Fix
Initialize the carry with the same `out_sharding` as the loop body output (one-line change).

## Testing
Added a dense noising-matrix case to the ZERO-strategy parameterization of the distributed noise generation test (host-device emulation via `XLA_FLAGS`, same pattern as the existing cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)