### PR TITLE
Fix scale_then_privatize to match its documented contract

### DIFF
--- a/jax_privacy/optimizers.py
+++ b/jax_privacy/optimizers.py
@@ -100,7 +100,7 @@ class AugmentedGradientTransformation(NamedTuple):
   pre_clipping_transform: Callable[[optax.OptState], PreClippingTransform]
 
 
-def _find_adaptive_state(state: optax.OptState) -> optax.Updates:
+def _find_adaptive_state_impl(state: optax.OptState) -> optax.Updates | None:
   """Recursively searches for a recognized adaptive optimizer state."""
   # These are all adaptive optimizers where the square root of the second
   # moments of gradients is the appropriate scaling.
@@ -116,18 +116,26 @@ def _find_adaptive_state(state: optax.OptState) -> optax.Updates:
   # If the state is a tuple/list (e.g., from optax.chain), search recursively.
   if isinstance(state, (tuple, list)):
     for sub_state in state:
-      result = _find_adaptive_state(sub_state)
+      result = _find_adaptive_state_impl(sub_state)
       if result is not None:
         return result
 
-  raise ValueError(
-      f'Could not find an adaptive optimizer state in {type(state)}.'
-      ' scale_then_privatize requires an adaptive optimizer (e.g.,'
-      ' optax.adam, optax.adamw, optax.rmsprop, optax.adagrad). If you are'
-      ' using a custom adaptive optimizer, pass a custom'
-      ' `extract_preconditioner_from_state_fn` function to'
-      ' scale_then_privatize.'
-  )
+  return None
+
+
+def _find_adaptive_state(state: optax.OptState) -> optax.Updates:
+  """Finds a recognized adaptive optimizer state, raising if there is none."""
+  result = _find_adaptive_state_impl(state)
+  if result is None:
+    raise ValueError(
+        f'Could not find an adaptive optimizer state in {type(state)}.'
+        ' scale_then_privatize requires an adaptive optimizer (e.g.,'
+        ' optax.adam, optax.adamw, optax.rmsprop, optax.adagrad). If you are'
+        ' using a custom adaptive optimizer, pass a custom'
+        ' `extract_preconditioner_from_state_fn` function to'
+        ' scale_then_privatize.'
+    )
+  return result
 
 
 def scale_then_privatize(
@@ -194,7 +202,7 @@ def scale_then_privatize(
         lambda u, s: jnp.astype(scale_fn(u, s), u.dtype), updates, scaling
     )
 
-  def update(updates, state, params, **extra_args):
+  def update(updates, state, params=None, **extra_args):
     """Applies the inverse scaling transform, then the base optimizer update."""
     unscaled_updates = pre_clipping_transform(state, inverse=True)(updates)
     return base_optimizer.update(unscaled_updates, state, params, **extra_args)

--- a/tests/optimizers_test.py
+++ b/tests/optimizers_test.py
@@ -47,6 +47,28 @@ class FindAdaptiveStateTest(parameterized.TestCase):
     result = optimizers._find_adaptive_state(state)
     chex.assert_trees_all_equal_shapes_and_dtypes(result, params)
 
+  @parameterized.parameters(
+      dict(
+          optimizer=optax.chain(
+              optax.clip_by_global_norm(1.0),
+              optax.scale_by_adam(),
+              optax.scale(-0.1),
+          )
+      ),
+      dict(
+          optimizer=optax.chain(
+              optax.clip_by_global_norm(1.0),
+              optax.chain(optax.scale_by_adam(), optax.scale(-0.1)),
+          )
+      ),
+  )
+  def test_finds_adaptive_state_not_first_in_chain(self, optimizer):
+    """Should search past non-adaptive states, including in nested chains."""
+    params = {'w': jnp.ones(3)}
+    state = optimizer.init(params)
+    result = optimizers._find_adaptive_state(state)
+    chex.assert_trees_all_equal_shapes_and_dtypes(result, params)
+
   def test_raises_on_sgd_state(self):
     """Should raise ValueError for non-adaptive optimizer (SGD)."""
     opt = optax.sgd(1e-3)
@@ -114,6 +136,22 @@ class ScaleThenPrivatizeTest(parameterized.TestCase):
     scaled_grad = pct(grad)
     aug_updates, _ = augmented.update(scaled_grad, state, params)
     base_updates, _ = base_opt.update(grad, state, params)
+    chex.assert_trees_all_close(aug_updates, base_updates, atol=1e-6)
+
+  def test_update_params_defaults_to_none(self):
+    """update is callable without params, per the documented signature."""
+    base_opt = optax.adam(1e-3)
+    augmented = optimizers.scale_then_privatize(base_opt)
+    params = _init_params()
+    state = augmented.init(params)
+
+    # Run a step with the base optimizer to populate nu.
+    grad = jnp.array([0.1, 0.2, 0.3])
+    _, state = base_opt.update(grad, state, params)
+
+    scaled_grad = augmented.pre_clipping_transform(state)(grad)
+    aug_updates, _ = augmented.update(scaled_grad, state)
+    base_updates, _ = base_opt.update(grad, state)
     chex.assert_trees_all_close(aug_updates, base_updates, atol=1e-6)
 
   def test_custom_preconditioner_fn(self):


### PR DESCRIPTION
## Problem
Two contract violations in `scale_then_privatize`: (1) `_find_adaptive_state` raised on the *first* non-adaptive element of an `optax.chain` state instead of continuing the search, so documented configurations like `optax.chain(clip_by_global_norm(...), scale_by_adam(), scale(-lr))` could not train; (2) `update()` required `params` although the `AugmentedGradientTransformation` docstring documents `update(updates, state, params=None)`.

## Fix
The recursive search now returns `None` per element and raises only when no adaptive state exists anywhere in the tree; `params` defaults to `None` per the documented signature.

## Testing
Added tests for an adaptive state that is not the first chain element, nested chains, and the `params=None` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)