### PR TITLE
Fix clipped_fun to ignore dtype when grid_scale is set

### DIFF
--- a/jax_privacy/clipping.py
+++ b/jax_privacy/clipping.py
@@ -479,10 +479,11 @@ def clipped_fun(
 
     def clipped_fun_one_group(*args, is_padding_example, **kwargs):
       value, aux = fun(*args, **kwargs)
-      value = optax.tree.cast(value, dtype)
       if grid_scale is not None:
+        # dtype is intentionally ignored here; the output is always int64.
         clipped, norm = clip_and_round_to_grid(value, l2_clip_norm, grid_scale)
       else:
+        value = optax.tree.cast(value, dtype)
         clipped, norm = clip_pytree(value, l2_clip_norm, rescale_to_unit_norm)
       clipped = _maybe_zero(clipped, norm, is_padding_example, nan_safe)
       return clipped, aux, norm

--- a/tests/clipping_test.py
+++ b/tests/clipping_test.py
@@ -394,6 +394,27 @@ class ClippedFunGridScaleTest(parameterized.TestCase):
         result = cf3(data)
         self.assertLessEqual(float(optax.tree.norm(result)), grid_scale)
 
+  @parameterized.named_parameters(
+      dict(testcase_name='int32', dtype=jnp.int32),
+      dict(testcase_name='float16', dtype=jnp.float16),
+  )
+  def test_clipped_fun_grid_scale_ignores_dtype(self, dtype):
+    """Tests that dtype does not affect the values rounded to the grid."""
+    # The second example overflows float16 and must still be clipped to the
+    # grid rather than zeroed; the first is truncated to zero by int32.
+    data = jnp.array([[0.3, 0.4], [1e5, 0.0]])
+    kwargs = dict(
+        fun=lambda x: x,
+        batch_argnums=0,
+        keep_batch_dim=False,
+        l2_clip_norm=1.0,
+        grid_scale=1000,
+    )
+    with jax.enable_x64(True):
+      result = clipping.clipped_fun(dtype=dtype, **kwargs)(data)
+      expected = clipping.clipped_fun(dtype=None, **kwargs)(data)
+      chex.assert_trees_all_equal(result, expected)
+
   def test_clipped_grad_grid_scale(self):
     """Tests clipped_grad with grid_scale end-to-end."""
 


### PR DESCRIPTION
## Problem
fb60609 moved the `optax.tree.cast(value, dtype)` call out of the non-grid branch, so `dtype` now corrupts values **before** `clip_and_round_to_grid`: integer dtypes truncate gradients to zero, and float16 overflows to inf (after which the `nan_safe` norm check zeroes the example). Both the `clipped_fun` and `clip_pytree` docstrings promise 'When set [grid_scale], dtype is ignored'.

## Fix
Restore the cast to the non-grid branch only, matching the documented behavior.

## Testing
Added a test combining `dtype` with `grid_scale` asserting the rounded values are unaffected by the dtype argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)