### PR TITLE
ci(lint): add pyrefly type checking alongside pytype

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,9 @@ jobs:
           pytype jax_privacy -k
           pytype tests -k
           pytype examples -k
+      - name: Run pyrefly
+        run: |
+          pyrefly check
 
   test:
     name: "Unit Test: Python ${{ matrix.python-version }} on ${{ matrix.os }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,11 +99,13 @@ conventions depending on what is being contributed.
 
 ## Linting and testing
 
-We use `flake8`, `pylint` and `pytype` for linting and type checking. Please run
-the following commands locally before submitting a pull request:
+We use `flake8`, `pylint`, `pytype` and `pyrefly` for linting and type
+checking. Please run the following commands locally before submitting a pull
+request:
 
 ```bash
 $ flake8 jax_privacy/**.py
 $ pylint jax_privacy/**.py
 $ pytype jax_privacy/**.py
+$ pyrefly check
 ```

--- a/examples/secure_noise_example.py
+++ b/examples/secure_noise_example.py
@@ -68,11 +68,15 @@ GRID_SCALE = 10**9  # Number of integer grid steps per L2_CLIP_NORM.
 def _create_secure_prng() -> np.random.Generator:
   """Creates a cryptographically secure PRNG, falling back to standard NumPy."""
   try:
+    # Make sure this example still works in environments where randomgen is
+    # not installed.
     # pylint: disable-next=g-import-not-at-top,import-outside-toplevel
     import randomgen  # pytype: disable=import-error
 
     rng = randomgen.RDRAND()  # pytype: disable=module-attr
-    return np.random.Generator(rng)
+    # randomgen.RDRAND is a numpy BitGenerator at runtime, but its stubs do
+    # not declare that, so pyrefly wrongly rejects the argument.
+    return np.random.Generator(rng)  # pyrefly: ignore[bad-argument-type]
   except ImportError:
     warnings.warn(
         'randomgen is not installed. Falling back to a standard NumPy PRNG. '

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ lint = [
     "pylint",
     "pylint-exit",
     "pytype",
+    "pyrefly",
     "pyink",
     "pyink[jupyter]",
 ]
@@ -117,8 +118,20 @@ pyink-annotation-pragmas = [
   "pylint:",
   "type: ignore",
   "pytype:",
+  "pyrefly:",
   "mypy:",
   "pyright:",
   "pyre-",
 ]
+
+[tool.pyrefly]
+project-includes = [
+  "jax_privacy/**/*.py",
+  "tests/**/*.py",
+  "examples/**/*.py",
+]
+python-version = "3.11"
+# `basic` is the preset Pyrefly applies to unconfigured projects; pin it so the
+# checker level does not silently change just because this config exists.
+preset = "basic"
 


### PR DESCRIPTION
Adds pyrefly as a static type checker alongside the existing pytype checks, as discussed in #307.

## What changed
- `ci.yml`: keeps the pytype step and adds a `pyrefly check` step, so both run in CI.
- `pyproject.toml`: adds pyrefly to the `lint` extra next to pytype; adds a `pyrefly:` pyink pragma; adds a `[tool.pyrefly]` block scoped to `.py` files and pinned to the `basic` preset.
- `CONTRIBUTING.md`: lists pytype and pyrefly in the tool list and local commands.
- `secure_noise_example.py`: adds one pyrefly ignore for the numpy BitGenerator argument, keeps the existing pytype pragmas.

## Notes for review
- Both checkers run. Internal presubmit still runs pytype, so this complements rather than replaces it. All existing pytype pragmas are left in place.
- Scoped to Python files only, not notebooks. pyrefly checks notebooks by default and the example notebooks carry stale imports, so keeping the old `.py`-only scope avoids failing CI on pre-existing issues.
- Pinned to the `basic` preset. Adding any `[tool.pyrefly]` block silently switches pyrefly to its stricter `default` preset, which surfaces ~340 mostly numpy/jax array typing errors. `basic` matches pytype's current strictness and keeps CI green. Moving toward `default` later can be a separate pass.

Verified locally: flake8, pyink, pydocstyle, pylint, and pyrefly all pass.

Closes #307
