### PR TITLE
Require jax>=0.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ requires-python = ">=3.11"
 dependencies = [
     "absl-py>=1.2.0",
     "dp_accounting @ git+https://github.com/google/differential-privacy.git#subdirectory=python/dp_accounting",
-    "jax>=0.7.1",
-    "jaxlib>=0.7.1",
+    "jax>=0.8.1",
+    "jaxlib>=0.8.1",
     "numpy>=2.0.0",
     "optax @ git+https://github.com/google-deepmind/optax.git",
     "scipy>=1.9.2",


### PR DESCRIPTION
Per discussion below: `DPTrainer.train_step` uses the bare `@jax.jit(...)` decorator, which is only valid on `jax>=0.8.1`. On 0.7.x and 0.8.0, `jax.jit` requires `fun` positionally, so the decorator raises `TypeError: jit() missing 1 required positional argument: 'fun'` at import time, breaking `jax_privacy.keras_api` and the Keras example notebooks on current Colab (jax 0.7.2).

Following @ryan112358's preference (option 2), this bumps the `jax` and `jaxlib` minimums to `0.8.1` rather than changing the decorator. This also covers the sharding-in-types fixes introduced in 0.8.0 and the optax features that require a newer jax.

I confirmed the crossover by testing across versions: the bare form fails on 0.7.x and 0.8.0 and works on 0.8.1 through 0.11.0.

cc @RamSaw