### PR TITLE
Fix Keras DP train_step RNG/step counters to update by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ The format is based on https://keepachangelog.com/en/1.1.0/
 
 ### Fixed
 
+-   **Keras DP state indexing**: `make_private()` now records the indices of
+    ``_rng`` / ``_optimizer_steps`` by name and updates those slots in
+    ``train_step``. Hard-coded ``[0]`` / ``[1]`` broke whenever the model
+    already had non-trainable weights (for example a prior ``add_weight``),
+    treating user state as the noise PRNG key.
 -   **`clipped_fun` Formal Guarantees**: Replaced the incorrect claim that
     sensitivity is always `1.0` / `l2_clip_norm` with guidance to use
     ``.sensitivity()`` / ``.l2_norm_bound``, matching `clipped_grad`. The old

--- a/jax_privacy/keras_api.py
+++ b/jax_privacy/keras_api.py
@@ -380,7 +380,8 @@ def _add_dp_sgd_attributes(model: keras.Model, params: DPKerasConfig) -> None:
       trainable=False,
   )
   # Record indices once. Non-trainable order is not stable across models (e.g.
-  # prior add_weight / BatchNorm stats), so train_step must not hard-code [0]/1].
+  # prior add_weight / BatchNorm stats), so train_step must not hard-code
+  # indices 0 and 1.
   model._dp_rng_index = _non_trainable_index(model, '_rng')  # pylint: disable=protected-access
   model._dp_optimizer_steps_index = _non_trainable_index(  # pylint: disable=protected-access
       model, '_optimizer_steps'

--- a/jax_privacy/keras_api.py
+++ b/jax_privacy/keras_api.py
@@ -379,6 +379,35 @@ def _add_dp_sgd_attributes(model: keras.Model, params: DPKerasConfig) -> None:
       dtype='uint32',
       trainable=False,
   )
+  # Record indices once. Non-trainable order is not stable across models (e.g.
+  # prior add_weight / BatchNorm stats), so train_step must not hard-code [0]/1].
+  model._dp_rng_index = _non_trainable_index(model, '_rng')  # pylint: disable=protected-access
+  model._dp_optimizer_steps_index = _non_trainable_index(  # pylint: disable=protected-access
+      model, '_optimizer_steps'
+  )
+
+
+def _non_trainable_index(model: keras.Model, weight_name: str) -> int:
+  """Returns the index of ``weight_name`` in ``model.non_trainable_weights``."""
+  for index, weight in enumerate(model.non_trainable_weights):
+    if weight.name == weight_name:
+      return index
+  raise ValueError(
+      f'Expected non-trainable weight named {weight_name!r} on model'
+      f' {model.name!r}, but it was not found. Available:'
+      f' {[w.name for w in model.non_trainable_weights]}.'
+  )
+
+
+def _replace_non_trainable(
+    non_trainable_variables: list[jax.Array],
+    index: int,
+    value: jax.Array,
+) -> list[jax.Array]:
+  """Returns a copy of ``non_trainable_variables`` with ``index`` replaced."""
+  updated = list(non_trainable_variables)
+  updated[index] = value
+  return updated
 
 
 _FitFnReturnType = keras.callbacks.History
@@ -869,8 +898,12 @@ def _dp_train_step(
   ) = self.optimizer.stateless_apply(
       optimizer_variables, grads, trainable_variables
   )
-  # TODO: b/415360727 - access it and update it by name.
-  non_trainable_variables[1] = non_trainable_variables[1] + 1
+  steps_index = self._dp_optimizer_steps_index  # pylint: disable=protected-access
+  non_trainable_variables = _replace_non_trainable(
+      non_trainable_variables,
+      steps_index,
+      non_trainable_variables[steps_index] + 1,
+  )
 
   logs, metrics_variables = self._update_metrics_variables(  # pylint: disable=protected-access
       metrics_variables, unscaled_loss, x, y, y_pred, sample_weight
@@ -956,8 +989,14 @@ def _noised_clipped_grads(
       optimizer_variables,
       metrics_variables,
   ) = state
-  # TODO: b/415360727 - access it and update it by name.
-  noise_state = non_trainable_variables[0], ()
+  # Prefer indices recorded by make_private(); fall back to 0 for unit tests
+  # that call this helper with a synthetic state whose only non-trainable is
+  # the noise RNG.
+  if model is not None and hasattr(model, '_dp_rng_index'):
+    rng_index = model._dp_rng_index  # pylint: disable=protected-access
+  else:
+    rng_index = 0
+  noise_state = non_trainable_variables[rng_index], ()
   x, y, sample_weight = keras.utils.unpack_x_y_sample_weight(data)
   if is_padding_example is None:
     if dp_params.poisson_sampling_in_fit and sample_weight is not None:
@@ -1001,7 +1040,9 @@ def _noised_clipped_grads(
   loss = _masked_mean(per_example_aux.values, is_padding_example)
   unscaled_loss = _masked_mean(per_example_aux.aux[0], is_padding_example)
   y_pred = per_example_aux.aux[1]
-  non_trainable_variables = [new_noise_state[0]] + non_trainable_variables[1:]
+  non_trainable_variables = _replace_non_trainable(
+      non_trainable_variables, rng_index, new_noise_state[0]
+  )
   # Metrics follow the same masked-mean reduction as the loss values above.
   new_metrics = jax.tree.map(
       lambda x: _masked_mean(x, is_padding_example),

--- a/tests/keras_api_test.py
+++ b/tests/keras_api_test.py
@@ -181,6 +181,95 @@ class KerasApiTest(parameterized.TestCase):
     self.assertTrue(hasattr(model, "_dp_params"))
     self.assertEqual(model._dp_params, params)
     self.assertEqual(model._dp_noise_multiplier, params.noise_multiplier)
+    self.assertEqual(
+        model.non_trainable_weights[model._dp_rng_index].name, "_rng"
+    )
+    self.assertEqual(
+        model.non_trainable_weights[model._dp_optimizer_steps_index].name,
+        "_optimizer_steps",
+    )
+
+  def test_dp_state_indices_skip_prior_non_trainables(self):
+    """DP RNG/step slots must not assume they occupy indices 0 and 1."""
+    inputs = keras.Input(shape=(4,))
+    outputs = keras.layers.Dense(1)(inputs)
+    model = keras.Model(inputs, outputs)
+    model.add_weight(
+        name="prior_state",
+        shape=(3,),
+        initializer="ones",
+        trainable=False,
+    )
+    _ = model(np.ones((2, 4), dtype=np.float32))
+    params = keras_api.DPKerasConfig(
+        epsilon=8.0,
+        delta=1e-5,
+        clipping_norm=1.0,
+        batch_size=4,
+        gradient_accumulation_steps=1,
+        train_steps=8,
+        train_size=16,
+        noise_multiplier=1.0,
+        seed=7,
+    )
+    keras_api.make_private(model, params)
+
+    names = [w.name for w in model.non_trainable_weights]
+    self.assertIn("prior_state", names)
+    self.assertGreater(model._dp_rng_index, 0)
+    self.assertGreater(model._dp_optimizer_steps_index, 0)
+    self.assertEqual(names[model._dp_rng_index], "_rng")
+    self.assertEqual(names[model._dp_optimizer_steps_index], "_optimizer_steps")
+
+  def test_fit_preserves_prior_non_trainable_and_advances_dp_state(self):
+    """Regression: prior non-trainables used to be treated as the DP RNG."""
+    inputs = keras.Input(shape=(4,))
+    outputs = keras.layers.Dense(1)(inputs)
+    model = keras.Model(inputs, outputs)
+    model.add_weight(
+        name="prior_state",
+        shape=(3,),
+        initializer="ones",
+        trainable=False,
+    )
+    model.compile(optimizer=keras.optimizers.SGD(0.1), loss="mse")
+    _ = model(np.ones((2, 4), dtype=np.float32))
+    params = keras_api.DPKerasConfig(
+        epsilon=8.0,
+        delta=1e-5,
+        clipping_norm=1.0,
+        batch_size=4,
+        gradient_accumulation_steps=1,
+        train_steps=8,
+        train_size=16,
+        noise_multiplier=1.0,
+        seed=11,
+    )
+    keras_api.make_private(model, params)
+
+    prior_before = np.array(
+        keras_api._get_non_trainable_weight("prior_state", model)
+    )
+    rng_before = np.array(keras_api._get_non_trainable_weight("_rng", model))
+    steps_before = np.array(
+        keras_api._get_non_trainable_weight("_optimizer_steps", model)
+    )
+
+    x = np.random.randn(16, 4).astype(np.float32)
+    y = np.random.randn(16, 1).astype(np.float32)
+    model.fit(x, y, batch_size=4, epochs=1, verbose=0)
+
+    prior_after = np.array(
+        keras_api._get_non_trainable_weight("prior_state", model)
+    )
+    rng_after = np.array(keras_api._get_non_trainable_weight("_rng", model))
+    steps_after = np.array(
+        keras_api._get_non_trainable_weight("_optimizer_steps", model)
+    )
+
+    np.testing.assert_array_equal(prior_before, prior_after)
+    self.assertFalse(np.array_equal(rng_before, rng_after))
+    self.assertGreater(int(steps_after.item()), int(steps_before.item()))
 
   def test_get_noise_multiplier_uses_config_value(self):
     model = keras.Sequential([keras.layers.Dense(10, input_shape=(784,))])


### PR DESCRIPTION
## Summary

* `make_private()` now records the indices of `_rng` and `_optimizer_steps` by name after adding them.
* `_dp_train_step` / `_noised_clipped_grads` update those slots instead of hard-coded `[0]` / `[1]`.
* Fixes a real failure mode: if the model already has non-trainable weights (e.g. a prior `add_weight`), index `0` is user state — the old code treated it as the noise PRNG key and crashed (or silently corrupted state).

This is not tied to an existing GitHub issue; it addresses the known internal TODO to access DP state by name.

## Test plan

* [x] `pytest tests/keras_api_test.py::KerasApiTest::test_dp_state_indices_skip_prior_non_trainables`
* [x] `pytest tests/keras_api_test.py::KerasApiTest::test_fit_preserves_prior_non_trainable_and_advances_dp_state`
* [x] Existing `test_add_dp_sgd_attributes` still passes
* [x] CI on this PR