### PR TITLE
Add privacy-correct Flax Linen MNIST example for jax_privacy 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ The format is based on https://keepachangelog.com/en/1.1.0/
 
 ## [Unreleased]
 
+### Added
+
+-   **`examples/dp_sgd_flax_linen_mnist.py`**: Privacy-correct Flax Linen CNN
+    MNIST training example for jax_privacy 2.x (`clipped_grad`, Poisson
+    sampling, PLD calibration). Replaces the deprecated 1.0-only notebook
+    path; `flax` added under the `examples` optional extras.
+
 ### Fixed
 
 -   **`clipped_fun` Formal Guarantees**: Replaced the incorrect claim that

--- a/docs/examples_guide.md
+++ b/docs/examples_guide.md
@@ -111,15 +111,33 @@ Shows both DP and non-DP training paths for comparison.
 with fixed-size batches (`drop_remainder=True`) rather than Poisson sampling,
 and divides gradients by the fixed batch size.
 
-### `dp_sgd_flax_linen_mnist.ipynb` (notebook)
+### `dp_sgd_flax_linen_mnist.py`
+
+End-to-end DP-SGD training of a Flax Linen CNN on MNIST using the current
+2.x API: PLD noise calibration, Poisson batch selection
+(`CyclicPoissonSampling`), `clipped_grad`, and `gaussian_privatizer`.
+
+```bash
+# Smoke run (few steps):
+python examples/dp_sgd_flax_linen_mnist.py --smoke
+
+# Full run (~ε=1, δ=1e-5; expects ~92% test accuracy):
+python examples/dp_sgd_flax_linen_mnist.py
+```
+
+Requires the `examples` optional extras (including `flax`).
+
+**Correctness status:** ✅ Privacy-correct. Uses Poisson sampling with
+matching `dpsgd_event` accounting and expected-batch-size normalization.
+
+### `dp_sgd_flax_linen_mnist.ipynb` (notebook, legacy)
 
 Step-by-step Colab tutorial that trains a Flax Linen CNN on MNIST with
-DP-SGD. Walks through hyper-parameter setup, PLD-based noise calibration,
-per-example gradient clipping via `dp_sgd.grad_clipping`, and comparing DP
-vs. non-DP accuracy.
+DP-SGD. **Deprecated:** only works with `jax-privacy==1.0` and the removed
+`jax_privacy.dp_sgd` API. Prefer `dp_sgd_flax_linen_mnist.py` above.
 
-**Correctness status:** Research / demonstration. Uses `tf.data` shuffling
-with fixed-size batches rather than Poisson sampling.
+**Correctness status:** Research / demonstration (legacy). Uses `tf.data`
+shuffling with fixed-size batches rather than Poisson sampling.
 
 ### `dp_sgd_keras_gemma3_lora_finetuning_samsum.ipynb` (notebook)
 

--- a/examples/dp_sgd_flax_linen_mnist.ipynb
+++ b/examples/dp_sgd_flax_linen_mnist.ipynb
@@ -1,10 +1,10 @@
 {
   "cells": [
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "6y958y4LvRb7"
       },
-      "cell_type": "markdown",
       "source": [
         "<div style=\"margin-bottom: 1em;\">\n",
         "  <a href=\"https://colab.research.google.com/github/google-deepmind/jax_privacy/blob/main/examples/dp_sgd_flax_linen_mnist.ipynb\" target=\"_blank\">\n",
@@ -17,10 +17,10 @@
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "nKRIApHooE1i"
       },
-      "cell_type": "code",
       "source": [
         "# @title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -34,20 +34,22 @@
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
       ],
-      "outputs": [],
-      "execution_count": null
+      "execution_count": null,
+      "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "HnYgGmIsZ_cT"
       },
-      "cell_type": "markdown",
       "source": [
         "# DP-SGD tutorial using Flax Linen on MNIST\n",
         "\n",
         "> **⚠️ Important:** This notebook does **not** work with `jax-privacy` at GitHub\n",
-        "> head. It requires `pip install jax-privacy==1.0`. For an up-to-date example\n",
-        "> of DP training with the current JAX Privacy API, see\n",
+        "> head. It requires `pip install jax-privacy==1.0`. For a privacy-correct\n",
+        "> Flax Linen MNIST example on the current 2.x API (Poisson sampling +\n",
+        "> `clipped_grad`), run [`dp_sgd_flax_linen_mnist.py`](dp_sgd_flax_linen_mnist.py).\n",
+        "> For BandMF logistic regression, see\n",
         "> [`dp_logistic_regression.py`](dp_logistic_regression.py).\n",
         "\n",
         "**Copyright 2025 DeepMind Technologies Limited.**\n",
@@ -60,10 +62,10 @@
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "G3wqHQg6f_JG"
       },
-      "cell_type": "markdown",
       "source": [
         "## Install libraries\n",
         "\n",
@@ -71,10 +73,10 @@
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "Ajj40XuZblzw"
       },
-      "cell_type": "code",
       "source": [
         "%%capture\n",
         "\n",
@@ -84,14 +86,14 @@
         "\n",
         "!pip install jax_privacy==1.0.0"
       ],
-      "outputs": [],
-      "execution_count": null
+      "execution_count": null,
+      "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "nXrfdOwff_JH"
       },
-      "cell_type": "markdown",
       "source": [
         "## Define hyper-parameters\n",
         "\n",
@@ -103,10 +105,10 @@
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "4zMInN-sf_JH"
       },
-      "cell_type": "code",
       "source": [
         "from jax_privacy.dp_sgd import grad_clipping\n",
         "\n",
@@ -152,14 +154,14 @@
         "# There is also UNROLLED which is slower but uses less memory because it uses lax.scan and each example is summed and clipped sequentially.\n",
         "per_example_grad_method = grad_clipping.VECTORIZED"
       ],
-      "outputs": [],
-      "execution_count": 145
+      "execution_count": 145,
+      "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "MPBxamhgf_JH"
       },
-      "cell_type": "markdown",
       "source": [
         "## Load the MNIST dataset\n",
         "\n",
@@ -169,10 +171,10 @@
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "9KiZ1oxlf_JH"
       },
-      "cell_type": "code",
       "source": [
         "import tensorflow as tf  # TensorFlow / `tf.data` operations.\n",
         "import tensorflow_datasets as tfds  # TFDS to download MNIST.\n",
@@ -212,14 +214,14 @@
         "# Group into batches of `batch_size` and skip incomplete batches, prefetch the next sample to improve latency.\n",
         "test_ds = test_ds.batch(batch_size, drop_remainder=True).prefetch(1)"
       ],
-      "outputs": [],
-      "execution_count": 146
+      "execution_count": 146,
+      "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "cGZqLWiwTMxS"
       },
-      "cell_type": "markdown",
       "source": [
         "## Define the CNN model with Flax Linen\n",
         "\n",
@@ -227,10 +229,10 @@
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "75AgdOKgf_JH"
       },
-      "cell_type": "code",
       "source": [
         "from flax import linen as nn\n",
         "\n",
@@ -252,14 +254,14 @@
         "    x = nn.Dense(features=10)(x)\n",
         "    return x"
       ],
-      "outputs": [],
-      "execution_count": 147
+      "execution_count": 147,
+      "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "G-CGa7N3TMxS"
       },
-      "cell_type": "markdown",
       "source": [
         "## Create model and Flax Linen train state\n",
         "\n",
@@ -267,10 +269,10 @@
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "1QiCRBKdTMxS"
       },
-      "cell_type": "code",
       "source": [
         "from flax.training import train_state\n",
         "from jax import random\n",
@@ -288,14 +290,14 @@
         "\n",
         "train_state = create_train_state(random.key(0))"
       ],
-      "outputs": [],
-      "execution_count": 148
+      "execution_count": 148,
+      "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "RxbE1O25TMxS"
       },
-      "cell_type": "markdown",
       "source": [
         "## Create DP-SGD gradient computer\n",
         "\n",
@@ -305,10 +307,10 @@
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "GL0Qd8UnTMxS"
       },
-      "cell_type": "code",
       "source": [
         "from jax_privacy.accounting import accountants, analysis, calibrate\n",
         "from jax_privacy.dp_sgd import gradients\n",
@@ -335,14 +337,14 @@
         "    per_example_grad_method=per_example_grad_method,\n",
         ")"
       ],
-      "outputs": [],
-      "execution_count": 149
+      "execution_count": 149,
+      "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "QZG5aCuKTMxS"
       },
-      "cell_type": "markdown",
       "source": [
         "## Define loss function\n",
         "\n",
@@ -350,10 +352,10 @@
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "W0MtuXRCTMxS"
       },
-      "cell_type": "code",
       "source": [
         "def loss_fn(params, state, batch):\n",
         "  logits = state.apply_fn({'params': params}, batch['image'])\n",
@@ -362,14 +364,14 @@
         "  ).mean()\n",
         "  return loss, logits"
       ],
-      "outputs": [],
-      "execution_count": 150
+      "execution_count": 150,
+      "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "KPggzkyQTMxS"
       },
-      "cell_type": "markdown",
       "source": [
         "## Define evaluation function\n",
         "\n",
@@ -377,10 +379,10 @@
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "zdIuqNRxTMxS"
       },
-      "cell_type": "code",
       "source": [
         "import jax\n",
         "\n",
@@ -391,14 +393,14 @@
         "  accuracy = jnp.mean(jnp.argmax(logits, -1) == batch['label'])\n",
         "  return loss, accuracy"
       ],
-      "outputs": [],
-      "execution_count": 151
+      "execution_count": 151,
+      "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "kSRkb_7iYiWw"
       },
-      "cell_type": "markdown",
       "source": [
         "## Define non-DP train step\n",
         "\n",
@@ -406,10 +408,10 @@
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "dIjLDYy9YiWw"
       },
-      "cell_type": "code",
       "source": [
         "@jax.jit\n",
         "def non_dp_train_step(state, batch):\n",
@@ -421,14 +423,14 @@
         "  accuracy = jnp.mean(jnp.argmax(logits, -1) == batch['label'])\n",
         "  return new_state, {'loss': loss, 'accuracy': accuracy}"
       ],
-      "outputs": [],
-      "execution_count": 152
+      "execution_count": 152,
+      "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "fd4GWDVkTMxS"
       },
-      "cell_type": "markdown",
       "source": [
         "## Define DP-SGD train step\n",
         "\n",
@@ -450,10 +452,10 @@
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "F5FkPthzTMxS"
       },
-      "cell_type": "code",
       "source": [
         "from jax_privacy.dp_sgd import typing as jax_privacy_typing\n",
         "\n",
@@ -486,14 +488,14 @@
         "  accuracy = jnp.mean(jnp.argmax(logits, -1) == batch['label'])\n",
         "  return new_state, new_noise_state, {'loss': loss, 'accuracy': accuracy}"
       ],
-      "outputs": [],
-      "execution_count": 153
+      "execution_count": 153,
+      "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "BkFJGoH1TMxS"
       },
-      "cell_type": "markdown",
       "source": [
         "## Train\n",
         "\n",
@@ -503,10 +505,10 @@
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "id": "Rk_7mgKYTMxS"
       },
-      "cell_type": "code",
       "source": [
         "import time\n",
         "import numpy as np\n",
@@ -568,14 +570,14 @@
         "    )\n",
         "    checkpoint_start = time.time()"
       ],
-      "outputs": [],
-      "execution_count": 154
+      "execution_count": 154,
+      "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "FEPvh0YWZ_cT"
       },
-      "cell_type": "markdown",
       "source": []
     }
   ],

--- a/examples/dp_sgd_flax_linen_mnist.py
+++ b/examples/dp_sgd_flax_linen_mnist.py
@@ -1,0 +1,268 @@
+# coding=utf-8
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DP-SGD training of a Flax Linen CNN on MNIST (jax_privacy 2.x).
+
+Replaces the broken ``dp_sgd_flax_linen_mnist.ipynb`` tutorial, which only
+works with ``jax-privacy==1.0`` and the removed ``jax_privacy.dp_sgd`` API.
+
+Pipeline:
+  1. Calibrate Gaussian noise via ``accounting.dpsgd_event`` +
+     ``dp_accounting.calibrate_dp_mechanism`` (PLD accountant).
+  2. Sample batches with ``batch_selection.CyclicPoissonSampling``.
+  3. Per-example clip + sum with ``jax_privacy.clipped_grad`` (normalize by
+     expected batch size; pad empty Poisson draws).
+  4. Add noise with ``noise_addition.gaussian_privatizer``.
+
+Full run (defaults) targets roughly the old notebook setup (~92% test at
+ε≈1, δ=1e-5). For a CI smoke::
+
+  python examples/dp_sgd_flax_linen_mnist.py --smoke
+"""
+
+from typing import Any, Mapping, Tuple
+
+from absl import app
+from absl import flags
+import dp_accounting
+from flax import linen as nn
+import jax
+import jax.numpy as jnp
+import jax_privacy
+from jax_privacy import accounting
+from jax_privacy import batch_selection
+from jax_privacy import noise_addition
+import keras
+import numpy as np
+import optax
+
+_SMOKE = flags.DEFINE_bool(
+    'smoke',
+    False,
+    'CI smoke mode: few steps, no accuracy assertion.',
+)
+_TRAIN_STEPS = flags.DEFINE_integer(
+    'train_steps',
+    5000,
+    'Number of DP-SGD optimization steps.',
+)
+_EXPECTED_BATCH_SIZE = flags.DEFINE_integer(
+    'expected_batch_size',
+    256,
+    'Expected Poisson batch size (also used as normalize_by).',
+)
+_EPSILON = flags.DEFINE_float('epsilon', 1.0, 'Target ε.')
+_DELTA = flags.DEFINE_float('delta', 1e-5, 'Target δ.')
+_CLIPPING_NORM = flags.DEFINE_float(
+    'clipping_norm',
+    0.1,
+    'Per-example L2 clip norm (before rescale_to_unit_norm).',
+)
+_LEARNING_RATE = flags.DEFINE_float('learning_rate', 0.1, 'SGD learning rate.')
+_MOMENTUM = flags.DEFINE_float('momentum', 0.9, 'SGD momentum.')
+_EVAL_EVERY = flags.DEFINE_integer(
+    'eval_every',
+    200,
+    'Evaluate test accuracy every N steps (and at the end).',
+)
+_PADDING_MULTIPLE = flags.DEFINE_integer(
+    'padding_multiple',
+    32,
+    'Pad Poisson batches to a multiple of this size (limits JIT shapes).',
+)
+_SEED = flags.DEFINE_integer('seed', 0, 'PRNG seed.')
+
+
+class CNN(nn.Module):
+  """Simple CNN matching the legacy Flax Linen MNIST notebook."""
+
+  @nn.compact
+  def __call__(self, x: jax.Array) -> jax.Array:
+    x = nn.Conv(features=32, kernel_size=(3, 3))(x)
+    x = nn.relu(x)
+    x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
+    x = nn.Conv(features=64, kernel_size=(3, 3))(x)
+    x = nn.relu(x)
+    x = nn.avg_pool(x, window_shape=(2, 2), strides=(2, 2))
+    x = x.reshape((x.shape[0], -1))
+    x = nn.Dense(features=256)(x)
+    x = nn.relu(x)
+    x = nn.Dense(features=10)(x)
+    return x
+
+
+def load_mnist() -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+  """Loads MNIST as float32 images in [0, 1] with integer labels."""
+  (x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()
+  x_train = np.expand_dims(x_train.astype(np.float32) / 255.0, -1)
+  x_test = np.expand_dims(x_test.astype(np.float32) / 255.0, -1)
+  y_train = y_train.astype(np.int32)
+  y_test = y_test.astype(np.int32)
+  return x_train, y_train, x_test, y_test
+
+
+def loss_fn(
+    params: Mapping[str, Any],
+    images: jax.Array,
+    labels: jax.Array,
+    apply_fn: Any,
+) -> jax.Array:
+  """Scalar loss; clipped_grad evaluates this per example."""
+  logits = apply_fn({'params': params}, images)
+  return optax.softmax_cross_entropy_with_integer_labels(logits, labels).mean()
+
+
+def accuracy(
+    params: Mapping[str, Any],
+    images: np.ndarray,
+    labels: np.ndarray,
+    apply_fn: Any,
+    batch_size: int = 512,
+) -> float:
+  """Computes classification accuracy over a full dataset."""
+  correct = 0
+  total = images.shape[0]
+  for start in range(0, total, batch_size):
+    end = min(start + batch_size, total)
+    logits = apply_fn({'params': params}, jnp.asarray(images[start:end]))
+    preds = jnp.argmax(logits, axis=-1)
+    correct += int(jnp.sum(preds == jnp.asarray(labels[start:end])))
+  return correct / total
+
+
+def _pad_batch_indices(indices: np.ndarray, multiple: int) -> np.ndarray:
+  """Pads indices; empty Poisson draws become an all-padding batch."""
+  if indices.size == 0:
+    return np.full(multiple, -1, dtype=np.int32)
+  return batch_selection.pad_to_multiple_of(indices, multiple)
+
+
+def main(_):
+  train_steps = 50 if _SMOKE.value else _TRAIN_STEPS.value
+  eval_every = 25 if _SMOKE.value else _EVAL_EVERY.value
+  expected_batch_size = _EXPECTED_BATCH_SIZE.value
+  epsilon = _EPSILON.value
+  delta = _DELTA.value
+  clipping_norm = _CLIPPING_NORM.value
+  padding_multiple = _PADDING_MULTIPLE.value
+  seed = _SEED.value
+
+  x_train, y_train, x_test, y_test = load_mnist()
+  train_size = x_train.shape[0]
+  sampling_prob = expected_batch_size / train_size
+
+  model = CNN()
+  key = jax.random.key(seed)
+  params = model.init(key, jnp.ones([1, 28, 28, 1]))['params']
+  apply_fn = model.apply
+
+  def batched_loss(params, images, labels):
+    return loss_fn(params, images, labels, apply_fn)
+
+  make_event = lambda sigma: accounting.dpsgd_event(
+      sigma, train_steps, sampling_prob=sampling_prob
+  )
+  noise_multiplier = dp_accounting.calibrate_dp_mechanism(
+      dp_accounting.pld.PLDAccountant,
+      make_event,
+      target_epsilon=epsilon,
+      target_delta=delta,
+  )
+
+  grad_fn = jax_privacy.clipped_grad(
+      batched_loss,
+      l2_clip_norm=clipping_norm,
+      batch_argnums=(1, 2),
+      normalize_by=expected_batch_size,
+      rescale_to_unit_norm=True,
+  )
+  stddev = noise_multiplier * grad_fn.l2_norm_bound
+  privatizer = noise_addition.gaussian_privatizer(
+      stddev=stddev, prng_key=jax.random.key(seed + 1)
+  )
+
+  accountant = dp_accounting.pld.PLDAccountant()
+  accountant.compose(make_event(noise_multiplier))
+  achieved_epsilon = accountant.get_epsilon(target_delta=delta)
+
+  print(
+      f'Calibrated noise_multiplier={noise_multiplier:.4f}, '
+      f'stddev={stddev:.6f}, sampling_prob={sampling_prob:.6f}'
+  )
+  print(
+      f'Target (ε, δ)=({epsilon}, {delta}); '
+      f'achieved ε={achieved_epsilon:.4f} at δ={delta}'
+  )
+
+  optimizer = optax.sgd(_LEARNING_RATE.value, momentum=_MOMENTUM.value)
+  opt_state = optimizer.init(params)
+  noise_state = privatizer.init(params)
+
+  @jax.jit
+  def train_step(
+      params,
+      opt_state,
+      noise_state,
+      images,
+      labels,
+      is_padding_example,
+  ):
+    clipped_grads = grad_fn(
+        params, images, labels, is_padding_example=is_padding_example
+    )
+    noisy_grads, noise_state = privatizer.update(clipped_grads, noise_state)
+    updates, opt_state = optimizer.update(noisy_grads, opt_state)
+    params = optax.apply_updates(params, updates)
+    return params, opt_state, noise_state
+
+  strategy = batch_selection.CyclicPoissonSampling(
+      sampling_prob=sampling_prob,
+      iterations=train_steps,
+  )
+  rng = np.random.default_rng(seed)
+
+  for step, batch_idx in enumerate(
+      strategy.batch_iterator(num_examples=train_size, rng=rng)
+  ):
+    idx = _pad_batch_indices(batch_idx, padding_multiple)
+    is_padding = idx == -1
+    safe_idx = np.where(is_padding, 0, idx)
+    batch_images = jnp.asarray(x_train[safe_idx])
+    batch_labels = jnp.asarray(y_train[safe_idx])
+
+    params, opt_state, noise_state = train_step(
+        params,
+        opt_state,
+        noise_state,
+        batch_images,
+        batch_labels,
+        jnp.asarray(is_padding),
+    )
+
+    if step > 0 and (step % eval_every == 0 or step == train_steps - 1):
+      acc = accuracy(params, x_test, y_test, apply_fn)
+      print(f'Step {step}: test accuracy={acc * 100:.2f}%')
+
+  test_acc = accuracy(params, x_test, y_test, apply_fn)
+  print(f'Final ε={achieved_epsilon:.4f} (δ={delta})')
+  print(f'Final test accuracy={test_acc * 100:.2f}%')
+
+  if not _SMOKE.value:
+    # Full run should be well above chance; ~92% with default HPs.
+    assert test_acc > 0.80, f'Test accuracy {test_acc:.4f} is too low'
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ test = [
 examples = [
     "dinosaur",
     "equinox",
+    "flax",
     # orbax pulls orbax-checkpoint → uvloop (not supported on Windows)
     "orbax; sys_platform != 'win32'",
     "scikit-learn==1.5.0",


### PR DESCRIPTION
## Summary

* Add `examples/dp_sgd_flax_linen_mnist.py`: Flax Linen CNN on MNIST using the current 2.x API (`clipped_grad`, `CyclicPoissonSampling`, PLD `dpsgd_event` calibration, `gaussian_privatizer`).
* Document it in `docs/examples_guide.md` as privacy-correct; mark the legacy notebook as deprecated and point it at the new script.
* Add `flax` to the `examples` optional extras.

This fills the gap left by the removed `jax_privacy.dp_sgd` API: the existing notebook only works with `jax-privacy==1.0` and is not runnable at head. Not tied to an open GitHub issue.

## Test plan

* [x] `python examples/dp_sgd_flax_linen_mnist.py --smoke` (completed successfully; ε≈1, loss/accuracy printed)
* [x] CI on this PR