### PR TITLE
Add optional slack output to clipped gradients

### DIFF
--- a/jax_privacy/clipping.py
+++ b/jax_privacy/clipping.py
@@ -20,7 +20,7 @@ import dataclasses
 import functools
 import math
 import numbers
-from typing import Any, Callable, TypeAlias
+from typing import Any, Callable, NamedTuple, TypeAlias
 
 import dp_accounting
 import jax
@@ -35,6 +35,70 @@ ClippedTreeAndNorm = collections.namedtuple(
     '_ClippedTreeAndNorm', ['clipped', 'norm']
 )
 _REPLACE_SPECIAL = dp_accounting.NeighboringRelation.REPLACE_SPECIAL
+
+
+class ClippedGradOutput(NamedTuple):
+  """Gradient and slack fields forming a single primary query.
+
+  Both fields must be privatized together before ``slack`` is released.
+  """
+
+  gradient: PyTree
+  slack: jax.Array
+
+
+def _validate_slack_config(
+    slack_k: int | None,
+    l2_clip_norm: float | PyTree,
+    grid_scale: int | None,
+) -> float | None:
+  """Validates the clipping configurations supported by slack outputs."""
+  if slack_k is None:
+    return None
+  if isinstance(slack_k, bool) or not isinstance(slack_k, int):
+    raise TypeError('slack_k must be a Python integer or None.')
+  if slack_k <= 0:
+    raise ValueError('slack_k must be positive.')
+  if grid_scale is not None:
+    raise ValueError('slack_k is not supported with discrete grid clipping.')
+  if not jnp.isscalar(l2_clip_norm):
+    raise ValueError('slack_k requires static scalar global clipping.')
+  try:
+    clip_norm = float(l2_clip_norm)
+  except (TypeError, ValueError) as error:
+    raise TypeError('slack_k requires a static l2_clip_norm.') from error
+  if not math.isfinite(clip_norm) or clip_norm <= 0:
+    raise ValueError('slack_k requires a finite, positive l2_clip_norm.')
+  min_clip_norm = math.sqrt(float(jnp.finfo(jnp.float32).tiny))
+  max_clip_norm = math.sqrt(float(jnp.finfo(jnp.float32).max))
+  if not min_clip_norm <= clip_norm <= max_clip_norm:
+    raise ValueError(
+        'slack_k requires l2_clip_norm whose square is finite and normal '
+        'float32.'
+    )
+  return clip_norm
+
+
+def _slack_from_norm(
+    gradient_norm: jax.Array,
+    clipping_bound: float,
+    slack_k: int,
+    output_bound: float,
+) -> jax.Array:
+  """Constructs prefix-filled slack from an already-computed norm.
+
+  The squared slack fraction is at most the unused norm fraction, which keeps
+  the gradient and slack fields jointly bounded by ``output_bound``.
+  """
+  clip_norm = jnp.asarray(clipping_bound, dtype=gradient_norm.dtype)
+  k = jnp.asarray(slack_k, dtype=gradient_norm.dtype)
+  unused_fraction = jnp.clip((clip_norm - gradient_norm) / clip_norm, 0.0, 1.0)
+  fill = jnp.clip(
+      k * unused_fraction - jnp.arange(slack_k, dtype=gradient_norm.dtype),
+      0.0,
+      1.0,
+  )
+  return fill * jnp.asarray(output_bound, gradient_norm.dtype) / jnp.sqrt(k)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -424,6 +488,7 @@ def clipped_fun(
     prng_argnum: int | None = None,
     spmd_axis_name: str | None = None,
     grid_scale: int | None = None,
+    slack_k: int | None = None,
 ) -> BoundedSensitivityCallable:
   """Transforms a function to clip its output and sum across a batch.
 
@@ -498,6 +563,11 @@ def clipped_fun(
       Gaussian mechanism.  Incompatible with ``rescale_to_unit_norm=True`` and
       ``normalize_by != 1.0``.  When set, ``dtype`` is ignored (output is always
       ``jnp.int64``).
+    slack_k: If set, adds this many SlaClip coordinates as a separate slack
+      field of the sensitivity-bounded primary output. The returned value is a
+      :class:`ClippedGradOutput` whose fields must be privatized together. Only
+      static scalar global clipping with float32-or-wider primary outputs is
+      currently supported.
 
   Returns:
     A `BoundedSensitivityCallable` wrapping a new function `clip_fn` that
@@ -528,6 +598,9 @@ def clipped_fun(
   """
   if isinstance(batch_argnums, int):
     batch_argnums = (batch_argnums,)
+  slack_clip_norm = _validate_slack_config(slack_k, l2_clip_norm, grid_scale)
+  if slack_clip_norm is not None:
+    l2_clip_norm = slack_clip_norm
   if grid_scale is not None:
     _validate.discrete_clipping(
         grid_scale,
@@ -550,9 +623,33 @@ def clipped_fun(
       value = optax.tree.cast(value, dtype)
       if grid_scale is not None:
         clipped, norm = clip_and_round_to_grid(value, l2_clip_norm, grid_scale)
+        safety_norm = norm
+      elif slack_k is not None:
+        if any(
+            not jnp.issubdtype(x.dtype, jnp.floating)
+            or jnp.finfo(x.dtype).bits < 32
+            for x in jax.tree.leaves(value)
+        ):
+          raise TypeError(
+              'slack_k requires float32 or wider primary outputs; use'
+              ' dtype=jnp.float32.'
+          )
+        assert slack_clip_norm is not None
+        clipped, norm = clip_pytree(
+            value, slack_clip_norm, rescale_to_unit_norm
+        )
+        output_bound = 1.0 if rescale_to_unit_norm else slack_clip_norm
+        clipped = ClippedGradOutput(
+            gradient=clipped,
+            slack=_slack_from_norm(
+                norm, slack_clip_norm, slack_k, output_bound
+            ),
+        )
+        safety_norm = norm
       else:
         clipped, norm = clip_pytree(value, l2_clip_norm, rescale_to_unit_norm)
-      clipped = _maybe_zero(clipped, norm, is_padding_example, nan_safe)
+        safety_norm = norm
+      clipped = _maybe_zero(clipped, safety_norm, is_padding_example, nan_safe)
       return clipped, aux, norm
 
     num_real_mb = _num_real_microbatches(is_padding_example, microbatch_size)
@@ -662,6 +759,7 @@ def clipped_grad(
     prng_argnum: int | None = None,
     spmd_axis_name: str | None = None,
     grid_scale: int | None = None,
+    slack_k: int | None = None,
 ) -> BoundedSensitivityCallable:
   """Create a function to compute the sum of clipped gradients of fun.
 
@@ -707,7 +805,10 @@ def clipped_grad(
     Array(5.5, dtype=float32)
 
   Formal Guarantees:
-    For the gradient output:
+    For the primary output:
+      When ``slack_k`` is set, the primary output contains both the gradient
+      and slack fields of :class:`ClippedGradOutput`; otherwise it is the
+      gradient PyTree.
       The L2 sensitivity of the returned callable is a complex function of
       the input parameters (``l2_clip_norm``, ``rescale_to_unit_norm``,
       ``grid_scale``, per-layer clipping settings, etc.) and may change as
@@ -799,6 +900,12 @@ def clipped_grad(
       Gaussian mechanism.  Incompatible with ``rescale_to_unit_norm=True`` and
       ``normalize_by != 1.0``.  When set, ``dtype`` is ignored (output is always
       ``jnp.int64``).
+    slack_k: Optional number of SlaClip slack coordinates. When set, the
+      sensitivity-bounded primary output is a :class:`ClippedGradOutput`. Its
+      gradient and slack fields must be privatized together. The slack is built
+      from the same norm used for clipping after ``pre_clipping_transform``.
+      Only static scalar global clipping with float32-or-wider primary outputs
+      is currently supported.
 
   Returns:
     A `BoundedSensitivityCallable` wrapping a new function
@@ -817,6 +924,9 @@ def clipped_grad(
     `return_grad_norms=True`, and `aux` is `None` unless
     `has_aux=True`.  When present, these outputs are per-example
     (i.e., they retain a batch axis).
+
+    When ``slack_k`` is set, `grad` is a :class:`ClippedGradOutput`;
+    otherwise it retains the original gradient structure.
   """
   _validate_static_args(argnums, batch_argnums, normalize_by)
   fun = _normalize_fun_to_return_aux(fun, has_aux)
@@ -851,4 +961,5 @@ def clipped_grad(
       prng_argnum=prng_argnum,
       spmd_axis_name=spmd_axis_name,
       grid_scale=grid_scale,
+      slack_k=slack_k,
   )

--- a/jax_privacy/clipping.py
+++ b/jax_privacy/clipping.py
@@ -48,57 +48,55 @@ class ClippedGradOutput(NamedTuple):
 
 
 def _validate_slack_config(
-    slack_k: int | None,
+    slack: int | None,
     l2_clip_norm: float | PyTree,
     grid_scale: int | None,
-) -> float | None:
-  """Validates the clipping configurations supported by slack outputs."""
-  if slack_k is None:
-    return None
-  if isinstance(slack_k, bool) or not isinstance(slack_k, int):
-    raise TypeError('slack_k must be a Python integer or None.')
-  if slack_k <= 0:
-    raise ValueError('slack_k must be positive.')
+) -> None:
+  """Validate the clipping configurations supported by slack outputs."""
+  if slack is None:
+    return
+  if isinstance(slack, bool) or not isinstance(slack, int):
+    raise TypeError('slack must be a Python integer or None.')
+  if slack <= 0:
+    raise ValueError('slack must be positive.')
   if grid_scale is not None:
-    raise ValueError('slack_k is not supported with discrete grid clipping.')
+    raise ValueError('slack is not supported with discrete grid clipping.')
+  # TODO: Support one slack vector per clipping-bound leaf.
   if not jnp.isscalar(l2_clip_norm):
-    raise ValueError('slack_k requires static scalar global clipping.')
-  try:
-    clip_norm = float(l2_clip_norm)
-  except (TypeError, ValueError) as error:
-    raise TypeError('slack_k requires a static l2_clip_norm.') from error
-  if not math.isfinite(clip_norm) or clip_norm <= 0:
-    raise ValueError('slack_k requires a finite, positive l2_clip_norm.')
-  min_clip_norm = math.sqrt(float(jnp.finfo(jnp.float32).tiny))
-  max_clip_norm = math.sqrt(float(jnp.finfo(jnp.float32).max))
-  if not min_clip_norm <= clip_norm <= max_clip_norm:
-    raise ValueError(
-        'slack_k requires l2_clip_norm whose square is finite and normal '
-        'float32.'
-    )
-  return clip_norm
+    raise ValueError('slack requires scalar global clipping.')
 
 
 def _slack_from_norm(
     gradient_norm: jax.Array,
-    clipping_bound: float,
-    slack_k: int,
-    output_bound: float,
+    clipping_bound: jax.typing.ArrayLike,
+    slack: int,
+    rescale_to_unit_norm: bool,
 ) -> jax.Array:
-  """Constructs prefix-filled slack from an already-computed norm.
-
-  The squared slack fraction is at most the unused norm fraction, which keeps
-  the gradient and slack fields jointly bounded by ``output_bound``.
-  """
-  clip_norm = jnp.asarray(clipping_bound, dtype=gradient_norm.dtype)
-  k = jnp.asarray(slack_k, dtype=gradient_norm.dtype)
-  unused_fraction = jnp.clip((clip_norm - gradient_norm) / clip_norm, 0.0, 1.0)
+  """Construct prefix-filled slack from an already-computed norm."""
+  gradient_norm = jnp.asarray(gradient_norm, dtype=jnp.float32)
+  clip_norm = jnp.asarray(clipping_bound, dtype=jnp.float32)
+  valid_clip_norm = jnp.isfinite(clip_norm) & (clip_norm > 0)
+  safe_clip_norm = jnp.where(valid_clip_norm, clip_norm, 1.0)
+  unused_fraction = jnp.where(
+      valid_clip_norm,
+      jnp.clip(1.0 - gradient_norm / safe_clip_norm, 0.0, 1.0),
+      0.0,
+  )
+  unused_fraction = jnp.nan_to_num(unused_fraction, nan=0.0)
+  k = jnp.asarray(slack, dtype=jnp.float32)
   fill = jnp.clip(
-      k * unused_fraction - jnp.arange(slack_k, dtype=gradient_norm.dtype),
+      k * unused_fraction - jnp.arange(slack, dtype=jnp.float32),
       0.0,
       1.0,
   )
-  return fill * jnp.asarray(output_bound, gradient_norm.dtype) / jnp.sqrt(k)
+  # sum(fill**2) <= sum(fill) = k * unused_fraction, which preserves
+  # the joint gradient-and-slack L2 bound.
+  output_bound = (
+      1.0
+      if rescale_to_unit_norm
+      else jnp.where(valid_clip_norm, clip_norm, 0.0)
+  )
+  return fill * output_bound / jnp.sqrt(k)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -488,7 +486,7 @@ def clipped_fun(
     prng_argnum: int | None = None,
     spmd_axis_name: str | None = None,
     grid_scale: int | None = None,
-    slack_k: int | None = None,
+    slack: int | None = None,
 ) -> BoundedSensitivityCallable:
   """Transforms a function to clip its output and sum across a batch.
 
@@ -563,10 +561,10 @@ def clipped_fun(
       Gaussian mechanism.  Incompatible with ``rescale_to_unit_norm=True`` and
       ``normalize_by != 1.0``.  When set, ``dtype`` is ignored (output is always
       ``jnp.int64``).
-    slack_k: If set, adds this many SlaClip coordinates as a separate slack
-      field of the sensitivity-bounded primary output. The returned value is a
-      :class:`ClippedGradOutput` whose fields must be privatized together. Only
-      static scalar global clipping with float32-or-wider primary outputs is
+    slack: Optional number of SlaClip slack coordinates. Must be a positive
+      Python integer. When set, the returned value is a
+      :class:`ClippedGradOutput` whose fields must be privatized together.
+      Slack coordinates have float32 dtype. Only scalar global clipping is
       currently supported.
 
   Returns:
@@ -598,9 +596,7 @@ def clipped_fun(
   """
   if isinstance(batch_argnums, int):
     batch_argnums = (batch_argnums,)
-  slack_clip_norm = _validate_slack_config(slack_k, l2_clip_norm, grid_scale)
-  if slack_clip_norm is not None:
-    l2_clip_norm = slack_clip_norm
+  _validate_slack_config(slack, l2_clip_norm, grid_scale)
   if grid_scale is not None:
     _validate.discrete_clipping(
         grid_scale,
@@ -623,33 +619,14 @@ def clipped_fun(
       value = optax.tree.cast(value, dtype)
       if grid_scale is not None:
         clipped, norm = clip_and_round_to_grid(value, l2_clip_norm, grid_scale)
-        safety_norm = norm
-      elif slack_k is not None:
-        if any(
-            not jnp.issubdtype(x.dtype, jnp.floating)
-            or jnp.finfo(x.dtype).bits < 32
-            for x in jax.tree.leaves(value)
-        ):
-          raise TypeError(
-              'slack_k requires float32 or wider primary outputs; use'
-              ' dtype=jnp.float32.'
-          )
-        assert slack_clip_norm is not None
-        clipped, norm = clip_pytree(
-            value, slack_clip_norm, rescale_to_unit_norm
-        )
-        output_bound = 1.0 if rescale_to_unit_norm else slack_clip_norm
-        clipped = ClippedGradOutput(
-            gradient=clipped,
-            slack=_slack_from_norm(
-                norm, slack_clip_norm, slack_k, output_bound
-            ),
-        )
-        safety_norm = norm
       else:
         clipped, norm = clip_pytree(value, l2_clip_norm, rescale_to_unit_norm)
-        safety_norm = norm
-      clipped = _maybe_zero(clipped, safety_norm, is_padding_example, nan_safe)
+      if slack is not None:
+        slack_vector = _slack_from_norm(
+            norm, l2_clip_norm, slack, rescale_to_unit_norm
+        )
+        clipped = ClippedGradOutput(clipped, slack_vector)
+      clipped = _maybe_zero(clipped, norm, is_padding_example, nan_safe)
       return clipped, aux, norm
 
     num_real_mb = _num_real_microbatches(is_padding_example, microbatch_size)
@@ -759,7 +736,7 @@ def clipped_grad(
     prng_argnum: int | None = None,
     spmd_axis_name: str | None = None,
     grid_scale: int | None = None,
-    slack_k: int | None = None,
+    slack: int | None = None,
 ) -> BoundedSensitivityCallable:
   """Create a function to compute the sum of clipped gradients of fun.
 
@@ -806,7 +783,7 @@ def clipped_grad(
 
   Formal Guarantees:
     For the primary output:
-      When ``slack_k`` is set, the primary output contains both the gradient
+      When ``slack`` is set, the primary output contains both the gradient
       and slack fields of :class:`ClippedGradOutput`; otherwise it is the
       gradient PyTree.
       The L2 sensitivity of the returned callable is a complex function of
@@ -900,12 +877,12 @@ def clipped_grad(
       Gaussian mechanism.  Incompatible with ``rescale_to_unit_norm=True`` and
       ``normalize_by != 1.0``.  When set, ``dtype`` is ignored (output is always
       ``jnp.int64``).
-    slack_k: Optional number of SlaClip slack coordinates. When set, the
-      sensitivity-bounded primary output is a :class:`ClippedGradOutput`. Its
-      gradient and slack fields must be privatized together. The slack is built
-      from the same norm used for clipping after ``pre_clipping_transform``.
-      Only static scalar global clipping with float32-or-wider primary outputs
-      is currently supported.
+    slack: Optional number of SlaClip slack coordinates. Must be a positive
+      Python integer. When set, the sensitivity-bounded primary output is a
+      :class:`ClippedGradOutput`. Its gradient and slack fields must be
+      privatized together. The float32 slack is built from the same norm used
+      for clipping after ``pre_clipping_transform``. Only scalar global
+      clipping is currently supported.
 
   Returns:
     A `BoundedSensitivityCallable` wrapping a new function
@@ -925,7 +902,7 @@ def clipped_grad(
     `has_aux=True`.  When present, these outputs are per-example
     (i.e., they retain a batch axis).
 
-    When ``slack_k`` is set, `grad` is a :class:`ClippedGradOutput`;
+    When ``slack`` is set, `grad` is a :class:`ClippedGradOutput`;
     otherwise it retains the original gradient structure.
   """
   _validate_static_args(argnums, batch_argnums, normalize_by)
@@ -961,5 +938,5 @@ def clipped_grad(
       prng_argnum=prng_argnum,
       spmd_axis_name=spmd_axis_name,
       grid_scale=grid_scale,
-      slack_k=slack_k,
+      slack=slack,
   )

--- a/tests/gradient_clipping_test.py
+++ b/tests/gradient_clipping_test.py
@@ -387,26 +387,35 @@ class SlackClippingTest(parameterized.TestCase):
       (0.75, 1.0, 10, False, [1.0, 1.0, 0.5] + [0.0] * 7),
       (1.5, 2.0, 4, True, [1.0, 0.0, 0.0, 0.0]),
       (3.0, 2.0, 4, False, [0.0, 0.0, 0.0, 0.0]),
+      (0.0, 0.0, 4, False, [0.0, 0.0, 0.0, 0.0]),
   )
   def test_slack_from_norm(
-      self, norm, clip_norm, slack_k, rescale, expected_fill
+      self, norm, clip_norm, slack, rescale, expected_fill
   ):
     output_bound = 1.0 if rescale else clip_norm
-    slack = gradient_clipping._slack_from_norm(
-        jnp.asarray(norm), clip_norm, slack_k, output_bound
+    slack_vector = gradient_clipping._slack_from_norm(
+        jnp.asarray(norm), clip_norm, slack, rescale
     )
     expected = (
-        jnp.asarray(expected_fill) * output_bound / jnp.sqrt(float(slack_k))
+        jnp.asarray(expected_fill) * output_bound / jnp.sqrt(float(slack))
     )
 
-    chex.assert_trees_all_close(slack, expected, atol=1e-6)
+    chex.assert_trees_all_close(slack_vector, expected, atol=1e-6)
+
+  @parameterized.parameters(jnp.inf, jnp.nan, -1.0)
+  def test_invalid_clip_norm_returns_zero_slack(self, clip_norm):
+    slack_vector = gradient_clipping._slack_from_norm(
+        jnp.asarray(0.0), clip_norm, slack=4, rescale_to_unit_norm=False
+    )
+
+    chex.assert_trees_all_equal(slack_vector, jnp.zeros(4))
 
   @parameterized.product(
       norm_ratio=(0.0, 0.25, 1.0, 2.0),
-      slack_k=(1, 10),
+      slack=(1, 10),
       rescale=(False, True),
   )
-  def test_joint_output_respects_clip_bound(self, norm_ratio, slack_k, rescale):
+  def test_joint_output_respects_clip_bound(self, norm_ratio, slack, rescale):
     clip_norm = 2.0
     kwargs = dict(
         l2_clip_norm=clip_norm,
@@ -417,7 +426,7 @@ class SlackClippingTest(parameterized.TestCase):
         self._pytree_linear_loss, **kwargs
     )
     with_slack = gradient_clipping.clipped_grad(
-        self._pytree_linear_loss, slack_k=slack_k, **kwargs
+        self._pytree_linear_loss, slack=slack, **kwargs
     )
     params = {'a': jnp.zeros(1), 'b': jnp.zeros(1)}
     leaf_value = norm_ratio * clip_norm / jnp.sqrt(2.0)
@@ -439,7 +448,7 @@ class SlackClippingTest(parameterized.TestCase):
         keep_batch_dim=False,
         pre_clipping_transform=lambda grad: 2.0 * grad,
         return_grad_norms=True,
-        slack_k=4,
+        slack=4,
     )(jnp.zeros(1), jnp.array([[0.25]]))
 
     chex.assert_trees_all_close(output.gradient, jnp.array([0.5]))
@@ -453,7 +462,7 @@ class SlackClippingTest(parameterized.TestCase):
         keep_batch_dim=False,
         normalize_by=4.0,
         microbatch_size=2,
-        slack_k=4,
+        slack=4,
     )
     output = query(
         jnp.zeros(1),
@@ -474,7 +483,7 @@ class SlackClippingTest(parameterized.TestCase):
             l2_clip_norm=1.0,
             keep_batch_dim=False,
             microbatch_size=2,
-            slack_k=4,
+            slack=4,
         )
     )
     output = query(
@@ -490,7 +499,7 @@ class SlackClippingTest(parameterized.TestCase):
     kwargs = dict(l2_clip_norm=0.5, keep_batch_dim=False)
     legacy = gradient_clipping.clipped_grad(self._linear_loss, **kwargs)
     explicit_none = gradient_clipping.clipped_grad(
-        self._linear_loss, slack_k=None, **kwargs
+        self._linear_loss, slack=None, **kwargs
     )
     params = jnp.zeros(2)
     data = jnp.array([[0.3, 0.4], [3.0, 4.0]])
@@ -506,12 +515,12 @@ class SlackClippingTest(parameterized.TestCase):
       (True, TypeError),
       (1.5, TypeError),
   )
-  def test_rejects_invalid_slack_k(self, slack_k, error_type):
+  def test_rejects_invalid_slack(self, slack, error_type):
     with self.assertRaises(error_type):
       gradient_clipping.clipped_grad(
           self._linear_loss,
           l2_clip_norm=1.0,
-          slack_k=slack_k,
+          slack=slack,
       )
 
   def test_rejects_unsupported_clipping_configurations(self):
@@ -519,45 +528,62 @@ class SlackClippingTest(parameterized.TestCase):
       gradient_clipping.clipped_grad(
           self._linear_loss,
           l2_clip_norm={'layer': 1.0},
-          slack_k=4,
+          slack=4,
       )
     with self.assertRaisesRegex(ValueError, 'discrete grid clipping'):
       gradient_clipping.clipped_grad(
           self._linear_loss,
           l2_clip_norm=1.0,
           grid_scale=10,
-          slack_k=4,
+          slack=4,
       )
 
-  @parameterized.parameters(
-      -1.0, 0.0, 1e-50, 1e-30, 1e30, 1e100, jnp.inf, jnp.nan
-  )
-  def test_rejects_unsupported_clip_norm(self, clip_norm):
-    with self.assertRaises(ValueError):
-      gradient_clipping.clipped_grad(
+  @parameterized.parameters(False, True)
+  def test_dynamic_clip_norm_is_jittable(self, rescale):
+    params = jnp.zeros(1)
+    data = jnp.array([[0.75]])
+
+    def run(clip_norm):
+      query = gradient_clipping.clipped_grad(
           self._linear_loss,
           l2_clip_norm=clip_norm,
-          slack_k=4,
+          keep_batch_dim=False,
+          rescale_to_unit_norm=rescale,
+          slack=4,
       )
+      return query(params, data), query.l2_norm_bound
+
+    compiled = jax.jit(run).lower(jnp.asarray(1.0)).compile()
+    output_1, bound_1 = compiled(jnp.asarray(1.0))
+    output_2, bound_2 = compiled(jnp.asarray(2.0))
+
+    expected_gradient_2 = 0.375 if rescale else 0.75
+    expected_slack_2 = (
+        [0.5, 0.5, 0.25, 0.0] if rescale else [1.0, 1.0, 0.5, 0.0]
+    )
+    expected_bound_2 = 1.0 if rescale else 2.0
+    chex.assert_trees_all_close(output_1.gradient, jnp.array([0.75]))
+    chex.assert_trees_all_close(output_1.slack, jnp.array([0.5, 0.0, 0.0, 0.0]))
+    chex.assert_trees_all_close(
+        output_2.gradient, jnp.array([expected_gradient_2])
+    )
+    chex.assert_trees_all_close(output_2.slack, jnp.array(expected_slack_2))
+    chex.assert_trees_all_close(bound_1, jnp.array(1.0))
+    chex.assert_trees_all_close(bound_2, jnp.array(expected_bound_2))
 
   @parameterized.parameters(jnp.float16, jnp.bfloat16)
-  def test_low_precision_output_requires_cast(self, dtype):
-    kwargs = dict(
-        fun=self._linear_loss,
+  def test_slack_is_float32_for_low_precision_gradient(self, dtype):
+    output = gradient_clipping.clipped_grad(
+        self._linear_loss,
         l2_clip_norm=1.0,
         keep_batch_dim=False,
-        slack_k=1,
+        slack=1,
+    )(
+        jnp.zeros(1, dtype=dtype),
+        jnp.array([[0.5]], dtype=dtype),
     )
-    params = jnp.zeros(1, dtype=dtype)
-    data = jnp.array([[0.5]], dtype=dtype)
 
-    with self.assertRaisesRegex(TypeError, 'float32 or wider primary outputs'):
-      gradient_clipping.clipped_grad(**kwargs)(params, data)
-
-    output = gradient_clipping.clipped_grad(dtype=jnp.float32, **kwargs)(
-        params, data
-    )
-    self.assertEqual(output.gradient.dtype, jnp.float32)
+    self.assertEqual(output.gradient.dtype, dtype)
     self.assertEqual(output.slack.dtype, jnp.float32)
 
 

--- a/tests/gradient_clipping_test.py
+++ b/tests/gradient_clipping_test.py
@@ -18,6 +18,7 @@ import chex
 import jax
 import jax.numpy as jnp
 from jax_privacy import clipping as gradient_clipping
+import optax
 
 
 def mean_quadratic_loss(params: jax.Array, x: jax.Array) -> jax.Array:
@@ -369,6 +370,195 @@ class GradientClippingTest(parameterized.TestCase):
     )
     sum_grads = clipped_grad_fn(params, data, key)
     chex.assert_trees_all_equal_structs(sum_grads, params)
+
+
+class SlackClippingTest(parameterized.TestCase):
+
+  @staticmethod
+  def _linear_loss(params, example):
+    return jnp.sum(params * example)
+
+  @staticmethod
+  def _pytree_linear_loss(params, example):
+    return sum(jnp.sum(params[key] * example[key]) for key in params)
+
+  @parameterized.parameters(
+      (0.0, 2.0, 4, False, [1.0, 1.0, 1.0, 1.0]),
+      (0.75, 1.0, 10, False, [1.0, 1.0, 0.5] + [0.0] * 7),
+      (1.5, 2.0, 4, True, [1.0, 0.0, 0.0, 0.0]),
+      (3.0, 2.0, 4, False, [0.0, 0.0, 0.0, 0.0]),
+  )
+  def test_slack_from_norm(
+      self, norm, clip_norm, slack_k, rescale, expected_fill
+  ):
+    output_bound = 1.0 if rescale else clip_norm
+    slack = gradient_clipping._slack_from_norm(
+        jnp.asarray(norm), clip_norm, slack_k, output_bound
+    )
+    expected = (
+        jnp.asarray(expected_fill) * output_bound / jnp.sqrt(float(slack_k))
+    )
+
+    chex.assert_trees_all_close(slack, expected, atol=1e-6)
+
+  @parameterized.product(
+      norm_ratio=(0.0, 0.25, 1.0, 2.0),
+      slack_k=(1, 10),
+      rescale=(False, True),
+  )
+  def test_joint_output_respects_clip_bound(self, norm_ratio, slack_k, rescale):
+    clip_norm = 2.0
+    kwargs = dict(
+        l2_clip_norm=clip_norm,
+        keep_batch_dim=False,
+        rescale_to_unit_norm=rescale,
+    )
+    baseline = gradient_clipping.clipped_grad(
+        self._pytree_linear_loss, **kwargs
+    )
+    with_slack = gradient_clipping.clipped_grad(
+        self._pytree_linear_loss, slack_k=slack_k, **kwargs
+    )
+    params = {'a': jnp.zeros(1), 'b': jnp.zeros(1)}
+    leaf_value = norm_ratio * clip_norm / jnp.sqrt(2.0)
+    data = {key: jnp.array([[leaf_value]]) for key in params}
+
+    output = with_slack(params, data)
+    bound = 1.0 if rescale else clip_norm
+    tolerance = 4 * jnp.finfo(jnp.float32).eps * bound
+
+    chex.assert_trees_all_equal(output.gradient, baseline(params, data))
+    self.assertLessEqual(float(optax.tree.norm(output)), bound + tolerance)
+    self.assertEqual(with_slack.sensitivity(), baseline.sensitivity())
+    self.assertEqual(with_slack.l2_norm_bound, bound)
+
+  def test_slack_uses_post_transform_norm_but_aux_keeps_raw_norm(self):
+    output, aux = gradient_clipping.clipped_grad(
+        self._linear_loss,
+        l2_clip_norm=1.0,
+        keep_batch_dim=False,
+        pre_clipping_transform=lambda grad: 2.0 * grad,
+        return_grad_norms=True,
+        slack_k=4,
+    )(jnp.zeros(1), jnp.array([[0.25]]))
+
+    chex.assert_trees_all_close(output.gradient, jnp.array([0.5]))
+    chex.assert_trees_all_close(output.slack, jnp.array([0.5, 0.5, 0.0, 0.0]))
+    chex.assert_trees_all_close(aux.grad_norms, jnp.array([0.25]))
+
+  def test_microbatching_and_normalization(self):
+    query = gradient_clipping.clipped_grad(
+        self._linear_loss,
+        l2_clip_norm=1.0,
+        keep_batch_dim=False,
+        normalize_by=4.0,
+        microbatch_size=2,
+        slack_k=4,
+    )
+    output = query(
+        jnp.zeros(1),
+        jnp.array([[0.0], [0.5], [2.0], [2.0]]),
+    )
+
+    chex.assert_trees_all_close(output.gradient, jnp.array([0.625]))
+    chex.assert_trees_all_close(
+        output.slack, jnp.array([0.25, 0.25, 0.125, 0.125])
+    )
+    self.assertEqual(query.sensitivity(), 0.25)
+
+  @parameterized.parameters(jnp.nan, jnp.inf)
+  def test_padding_and_nonfinite_zero_full_output(self, nonfinite):
+    query = jax.jit(
+        gradient_clipping.clipped_grad(
+            self._linear_loss,
+            l2_clip_norm=1.0,
+            keep_batch_dim=False,
+            microbatch_size=2,
+            slack_k=4,
+        )
+    )
+    output = query(
+        jnp.zeros(1),
+        jnp.array([[0.0], [0.5], [nonfinite], [0.0]]),
+        is_padding_example=jnp.array([False, False, False, True]),
+    )
+
+    chex.assert_trees_all_close(output.gradient, jnp.array([0.5]))
+    chex.assert_trees_all_close(output.slack, jnp.array([1.0, 1.0, 0.5, 0.5]))
+
+  def test_none_preserves_legacy_output(self):
+    kwargs = dict(l2_clip_norm=0.5, keep_batch_dim=False)
+    legacy = gradient_clipping.clipped_grad(self._linear_loss, **kwargs)
+    explicit_none = gradient_clipping.clipped_grad(
+        self._linear_loss, slack_k=None, **kwargs
+    )
+    params = jnp.zeros(2)
+    data = jnp.array([[0.3, 0.4], [3.0, 4.0]])
+
+    chex.assert_trees_all_equal(
+        jax.jit(legacy)(params, data), jax.jit(explicit_none)(params, data)
+    )
+    self.assertEqual(legacy.sensitivity(), explicit_none.sensitivity())
+
+  @parameterized.parameters(
+      (0, ValueError),
+      (-1, ValueError),
+      (True, TypeError),
+      (1.5, TypeError),
+  )
+  def test_rejects_invalid_slack_k(self, slack_k, error_type):
+    with self.assertRaises(error_type):
+      gradient_clipping.clipped_grad(
+          self._linear_loss,
+          l2_clip_norm=1.0,
+          slack_k=slack_k,
+      )
+
+  def test_rejects_unsupported_clipping_configurations(self):
+    with self.assertRaisesRegex(ValueError, 'scalar global clipping'):
+      gradient_clipping.clipped_grad(
+          self._linear_loss,
+          l2_clip_norm={'layer': 1.0},
+          slack_k=4,
+      )
+    with self.assertRaisesRegex(ValueError, 'discrete grid clipping'):
+      gradient_clipping.clipped_grad(
+          self._linear_loss,
+          l2_clip_norm=1.0,
+          grid_scale=10,
+          slack_k=4,
+      )
+
+  @parameterized.parameters(
+      -1.0, 0.0, 1e-50, 1e-30, 1e30, 1e100, jnp.inf, jnp.nan
+  )
+  def test_rejects_unsupported_clip_norm(self, clip_norm):
+    with self.assertRaises(ValueError):
+      gradient_clipping.clipped_grad(
+          self._linear_loss,
+          l2_clip_norm=clip_norm,
+          slack_k=4,
+      )
+
+  @parameterized.parameters(jnp.float16, jnp.bfloat16)
+  def test_low_precision_output_requires_cast(self, dtype):
+    kwargs = dict(
+        fun=self._linear_loss,
+        l2_clip_norm=1.0,
+        keep_batch_dim=False,
+        slack_k=1,
+    )
+    params = jnp.zeros(1, dtype=dtype)
+    data = jnp.array([[0.5]], dtype=dtype)
+
+    with self.assertRaisesRegex(TypeError, 'float32 or wider primary outputs'):
+      gradient_clipping.clipped_grad(**kwargs)(params, data)
+
+    output = gradient_clipping.clipped_grad(dtype=jnp.float32, **kwargs)(
+        params, data
+    )
+    self.assertEqual(output.gradient.dtype, jnp.float32)
+    self.assertEqual(output.slack.dtype, jnp.float32)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

This PR is limited to the clipping primitive discussed in #317 and changes
only `jax_privacy/clipping.py` and `tests/gradient_clipping_test.py`.

- Add an optional positive integer `slack` argument to `clipped_fun` and
  `clipped_grad`.
- Build prefix-filled slack coordinates from the norm already computed by the
  existing clipping path, avoiding a second full-gradient norm traversal.
- Return `ClippedGradOutput(gradient, slack)` as one jointly
  sensitivity-bounded primary output. Both fields must be privatized together
  before slack is exposed.
- Preserve the original output structure and compiled path when `slack=None`.

## Design and scope

Slack construction is isolated in `_slack_from_norm`. It runs after
`pre_clipping_transform`, supports a dynamic scalar clipping bound, leaves the
gradient dtype unchanged, and emits float32 slack coordinates. The integer
`slack` argument remains static because it determines the output shape.

This first PR provides only the core private Slack Indicator primitive. It does
not add trainer integration, an adaptive threshold controller, CLI flags, or
CDF logging. A later controller can consume the privatized slack output without
changing this component.

The initial scope supports scalar global clipping. Discrete grid clipping and
PyTree clipping bounds are rejected when slack is enabled; per-leaf slack can
be added separately.

## Validation

- 2,245 tests passed across the repository's CI-compatible test shards.
- 16 module doctests passed.
- Pyink, Flake8, Pylint, Pytype, and Pyrefly passed.
- The lowered StableHLO for the disabled path is identical to upstream. The
  enabled path reuses the existing norm and adds only the slack construction
  and aggregation, not another full-gradient clipping pass.