### PR TITLE
Fix empty user selection batch shape

### DIFF
--- a/jax_privacy/batch_selection.py
+++ b/jax_privacy/batch_selection.py
@@ -638,7 +638,7 @@ class UserSelectionStrategy:
     unique, inverse = np.unique(user_ids, return_inverse=True)
     num_users = unique.size
     num_examples = user_ids.size
-    dtype = np.min_scalar_type(-num_examples)
+    dtype = np.min_scalar_type(-max(num_examples, 1))
 
     # Group example indices by user once to avoid an O(n) scan per user.
     order = np.argsort(inverse, kind='stable').astype(dtype, copy=False)
@@ -659,10 +659,11 @@ class UserSelectionStrategy:
     def get_user_batch(user_id):
       generator = user_generators[user_id]
       sample = itertools.islice(generator, examples_per_user)
-      return np.array(list(sample))
+      return np.array(list(sample), dtype=dtype)
 
     for user_batch in self.base_strategy.batch_iterator(num_users, rng):
-      yield np.array([get_user_batch(uid) for uid in user_batch])
+      batch = np.array([get_user_batch(uid) for uid in user_batch], dtype=dtype)
+      yield batch.reshape((-1, examples_per_user))
 
 
 # Re-export multi-owner functionality from _multi_owner submodule.

--- a/tests/batch_selection_test.py
+++ b/tests/batch_selection_test.py
@@ -491,6 +491,23 @@ class BatchSelectionTest(parameterized.TestCase):
     np.testing.assert_array_equal(batch[1], np.array([0, 1]))
     np.testing.assert_array_equal(batch[2], np.array([2, 3]))
 
+  @parameterized.named_parameters(
+      ('empty_sample', np.array([0, 1])),
+      ('empty_dataset', np.array([], dtype=np.int64)),
+  )
+  def test_user_selection_returns_typed_2d_empty_batch(self, user_ids):
+    base_strategy = batch_selection.CyclicPoissonSampling(
+        sampling_prob=0, iterations=1
+    )
+    strategy = batch_selection.UserSelectionStrategy(
+        base_strategy, examples_per_user_per_batch=2
+    )
+
+    batch = next(strategy.batch_iterator(user_ids, rng=0))
+
+    self.assertEqual(batch.shape, (0, 2))
+    self.assertTrue(np.issubdtype(batch.dtype, np.signedinteger))
+
   def test_fixed_batch_sampling(self):
     """Tests for FixedBatchSampling."""
     strategy = batch_selection.FixedBatchSampling(


### PR DESCRIPTION
## Summary

Keep empty `UserSelectionStrategy` batches two-dimensional and integer typed.

When no users were sampled, NumPy produced a `(0,)` float array instead of the documented `(0, examples_per_user)` index matrix. Empty batches now preserve the signed index dtype and expected rank, including for an empty dataset.

## Tests

- Covered empty Poisson samples
- Covered empty datasets
- Verified shape `(0, 2)` and signed integer dtype
